### PR TITLE
remove the version pinning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
 
     - name: install blackdoc
       shell: bash -l {0}
-      run: python -m pip install --no-warn-conflicts --no-deps .
+      run: python -m pip install .
 
     - name: show versions
       shell: bash -l {0}
@@ -59,7 +59,7 @@ jobs:
 #
 #    - name: install blackdoc
 #      shell: bash -l {0}
-#      run: python -m pip install --no-warn-conflicts --no-deps .
+#      run: python -m pip install .
 #
 #    - name: show versions
 #      shell: bash -l {0}
@@ -88,7 +88,7 @@ jobs:
 
     - name: install blackdoc
       shell: bash -l {0}
-      run: python -m pip install --no-warn-conflicts --no-deps .
+      run: python -m pip install .
 
     - name: show versions
       shell: bash -l {0}

--- a/ci/requirements/py36.yml
+++ b/ci/requirements/py36.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3.6
-  - black=19.10b0
+  - black
   - flake8
   - importlib-metadata
   - isort

--- a/ci/requirements/py37.yml
+++ b/ci/requirements/py37.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3.7
-  - black=19.10b0
+  - black
   - flake8
   - importlib-metadata
   - isort

--- a/ci/requirements/py38.yml
+++ b/ci/requirements/py38.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3.8
-  - black=19.10b0
+  - black
   - flake8
   - isort
   - more-itertools

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ classifiers =
 packages = find:
 python_requires = >=3.6
 install_requires =
-    black==19.10b0
+    black
     more_itertools
     importlib-metadata; python_version < "3.8"
 


### PR DESCRIPTION
After consideration, it turns out pinning the version of `black` in #16 was not as clever as I initially thought, so this reverts that change.