### PR TITLE
allow enabling / disabling certain formats

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: setup conda
-      uses: goanpeca/setup-miniconda@v1.3.1
+      uses: goanpeca/setup-miniconda@v1
       with:
         miniconda-version: "latest"
         activate-environment: blackdoc-tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: setup conda
-      uses: goanpeca/setup-miniconda@v1.1.2
+      uses: goanpeca/setup-miniconda@v1.3.1
       with:
         miniconda-version: "latest"
         activate-environment: blackdoc-tests

--- a/blackdoc/__main__.py
+++ b/blackdoc/__main__.py
@@ -279,7 +279,7 @@ def main():
         type=check_format_names,
         help=(
             "Disable the given formats. If both --formats and --disable-formats are present, "
-            "--disable-formats will also disable formats passed with --formats",
+            "--disable-formats will also disable formats passed with --formats"
         ),
     )
     parser.add_argument(


### PR DESCRIPTION
This adds the `--formats` and `--disable-formats` options that, when passed, will enable / disable applying `black` to the given formats.

- [x] closes #13