### PR TITLE
add pre-commit hook configuration

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+- id: blackdoc
+  name: blackdoc
+  entry: blackdoc
+  language: python
+  language_version: python3
+  require_serial: true
+  types: [python, rst]


### PR DESCRIPTION
To make it usable as a hook, we need to configure `pre-commit`.