### PR TITLE
fix the files matched by the pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,4 +4,5 @@
   language: python
   language_version: python3
   require_serial: true
-  types: [python, rst]
+  types: [file]
+  files: \.(py|rst)$


### PR DESCRIPTION
Since the `types` field matches using `AND`, trying to match both `python` and `rst` instead doesn't match anything.