### PR TITLE
make sure an error changes the return code

### DIFF
--- a/blackdoc/__main__.py
+++ b/blackdoc/__main__.py
@@ -192,7 +192,9 @@ def process(args):
 
     report = report_formatters.get(args.action)(n_reformatted, n_unchanged, n_error)
 
-    if args.action == "check" and n_reformatted > 0:
+    if n_error > 0:
+        return_code = 123
+    elif args.action == "check" and n_reformatted > 0:
         return_code = 1
     else:
         return_code = 0


### PR DESCRIPTION
This was a bug, obviously the return code has to change if we encounter an error. Not sure about the specific error code, though (is that what black returns when it encounters a `SyntaxError`?).