### PR TITLE
prepare the release of v0.1.1

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,6 @@
+black
+more-itertools
+flake8
+isort
+pytest
+coverage

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+v0.1.1 (14 May 2020)
+--------------------
+- Add pre-commit hook configuration (:pull:`26`, :pull:`27`)
+- Document the release process (:pull:`29`)
+- Make sure the tool returns a non-zero error code when encountering
+  syntax errors (:pull:`28`)
+
+
 v0.1 (30 May 2020)
 ------------------
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-black
-flake8
-more-itertools


### PR DESCRIPTION
The recently fixed bug that a parsing error doesn't change the error code justifies a new release (and the pre-commit configuration might be useful in increasing the adoption of the tool).