### PR TITLE
bugfix release

### DIFF
--- a/HOW_TO_RELEASE.rst
+++ b/HOW_TO_RELEASE.rst
@@ -73,3 +73,5 @@ Release process
        git push origin stable
 
 12. Make sure readthedocs builds both `stable` and the new tag
+
+13. Add a new section to the changelog and push directly to master

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,8 +1,8 @@
 Changelog
 =========
 
-v0.2 (unreleased)
------------------
+v0.1.2 (31 August 2020)
+-----------------------
 - keep compatibility with ``black`` 20.8b1 (:pull:`34`)
 
 v0.1.1 (14 June 2020)

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -3,7 +3,7 @@ Changelog
 
 v0.2 (unreleased)
 -----------------
-- keep compatibility with `black` 20.8b1 (:issue:`33`, :pull:`34`)
+- keep compatibility with ``black`` 20.8b1 (:pull:`34`)
 
 v0.1.1 (14 June 2020)
 ---------------------


### PR DESCRIPTION
The broken compatibility with `black` 20.08b1 requires a bugfix release. The new version of `black` also has lots of new CLI features, but those will need to be taken care of in a feature release.