### PR TITLE
empty doctest lines and docstrings in doctests

### DIFF
--- a/blackdoc/formats/doctest.py
+++ b/blackdoc/formats/doctest.py
@@ -4,8 +4,9 @@ import re
 import more_itertools
 
 name = "doctest"
+prompt_length = 4
 prompt = ">>>"
-prompt_re = re.compile(r"(>>> )")
+prompt_re = re.compile(r"(>>> ?)")
 continuation_prompt = "..."
 continuation_prompt_re = re.compile(r"(\.\.\. ?)")
 include_pattern = r"\.pyi?$"

--- a/blackdoc/formats/doctest.py
+++ b/blackdoc/formats/doctest.py
@@ -80,7 +80,7 @@ def extraction_func(line):
     return {"prompt_length": len(prompt) + 1}, extracted_line
 
 
-def reformatting_func(line):
+def reformatting_func(line, docstring_quotes):
     def add_prompt(prompt, line):
         if not line:
             return prompt
@@ -97,4 +97,8 @@ def reformatting_func(line):
             (add_prompt(continuation_prompt, line) for line in lines),
         )
     )
+    # make sure nested docstrings still work
+    if docstring_quotes == "'''":
+        reformatted = reformatted.replace('"""', "'''")
+
     return reformatted

--- a/blackdoc/tests/data/doctest.py
+++ b/blackdoc/tests/data/doctest.py
@@ -14,9 +14,17 @@ docstring = """ a function to open files
 
     >>> file.closed
     False
+
+    >>> def myfunc2(arg1, arg2):
+    ...     '''Docstring for function myfunc2 in docstring
+    ...
+    ...     More description of the function.
+    ...     '''
+    ...     pass
+    >>>
 """
 lines = docstring.split("\n")
-code_units = (1, 1, 1, 1, 4, 1, 1, 1, 1, 1, 1, 1, 1, 1)
+code_units = (1, 1, 1, 1, 4, 1, 1, 1, 1, 1, 1, 1, 1, 1, 6, 1)
 line_labels = (
     "none",
     "none",
@@ -35,4 +43,11 @@ line_labels = (
     "doctest",
     "none",
     "none",
+    "doctest",
+    "doctest",
+    "doctest",
+    "doctest",
+    "doctest",
+    "doctest",
+    "doctest",
 )

--- a/blackdoc/tests/data/doctest.py
+++ b/blackdoc/tests/data/doctest.py
@@ -24,7 +24,7 @@ docstring = """ a function to open files
     >>>
 """
 lines = docstring.split("\n")
-code_units = (1, 1, 1, 1, 4, 1, 1, 1, 1, 1, 1, 1, 1, 1, 6, 1)
+code_units = (1, 1, 1, 1, 4, 1, 1, 1, 1, 1, 1, 1, 1, 1, 6, 1, 1)
 line_labels = (
     "none",
     "none",
@@ -50,4 +50,5 @@ line_labels = (
     "doctest",
     "doctest",
     "doctest",
+    "none",
 )

--- a/blackdoc/tests/test_doctest.py
+++ b/blackdoc/tests/test_doctest.py
@@ -50,8 +50,9 @@ def test_detection_func(lines, expected):
     ),
 )
 def test_extraction_func(line):
+    docstring_quotes = '"""' if '"""' in line else "'''"
     expected = (
-        {"prompt_length": doctest.prompt_length},
+        {"prompt_length": doctest.prompt_length, "docstring_quotes": docstring_quotes},
         "\n".join(line.lstrip()[4:] for line in line.split("\n")),
     )
     actual = doctest.extraction_func(line)
@@ -69,11 +70,18 @@ def test_extraction_func(line):
             textwrap.dedent("\n".join(lines[17:23])),
             id="multiple lines with empty continuation line",
         ),
+        pytest.param(
+            textwrap.dedent("\n".join(lines[17:23]).replace("'''", '"""')),
+            id="multiple lines with inverted docstring quotes",
+        ),
     ),
 )
 def test_reformatting_func(expected):
+    docstring_quotes = "'''" if "'''" in expected else '"""'
     line = "\n".join(line.lstrip()[4:] for line in expected.split("\n"))
 
-    actual = doctest.reformatting_func(line)
+    actual = doctest.reformatting_func(line, docstring_quotes)
     assert expected == actual
-    assert '"""' not in actual
+
+    # make sure the docstring quotes were not changed
+    assert docstring_quotes not in expected or docstring_quotes in actual

--- a/blackdoc/tests/test_doctest.py
+++ b/blackdoc/tests/test_doctest.py
@@ -18,6 +18,14 @@ from .data.doctest import lines
             ((1, 5), doctest.name, "\n".join(lines[4:8])),
             id="multiple_lines",
         ),
+        pytest.param(
+            lines[23], ((1, 2), doctest.name, lines[23]), id="single empty line"
+        ),
+        pytest.param(
+            lines[17:23],
+            ((1, 7), doctest.name, "\n".join(lines[17:23])),
+            id="multiple lines with empty continuation line",
+        ),
     ),
 )
 def test_detection_func(lines, expected):
@@ -32,14 +40,18 @@ def test_detection_func(lines, expected):
 @pytest.mark.parametrize(
     "line",
     (
-        pytest.param(textwrap.dedent(lines[8]), id="single_line"),
-        pytest.param(textwrap.dedent("\n".join(lines[4:8])), id="multiple_lines"),
+        pytest.param(textwrap.dedent(lines[8]), id="single line"),
+        pytest.param(textwrap.dedent(lines[23]), id="single empty line"),
+        pytest.param(textwrap.dedent("\n".join(lines[4:8])), id="multiple lines"),
+        pytest.param(
+            textwrap.dedent("\n".join(lines[17:23])),
+            id="multiple lines with empty continuation line",
+        ),
     ),
 )
 def test_extraction_func(line):
-    prompt_length = len(doctest.prompt)
     expected = (
-        {"prompt_length": prompt_length},
+        {"prompt_length": doctest.prompt_length},
         "\n".join(line.lstrip()[4:] for line in line.split("\n")),
     )
     actual = doctest.extraction_func(line)
@@ -50,8 +62,13 @@ def test_extraction_func(line):
 @pytest.mark.parametrize(
     "expected",
     (
-        pytest.param(textwrap.dedent(lines[8]), id="single_line"),
-        pytest.param(textwrap.dedent("\n".join(lines[4:8])), id="multiple_lines"),
+        pytest.param(textwrap.dedent(lines[8]), id="single line"),
+        pytest.param(textwrap.dedent(lines[23]), id="single empty line"),
+        pytest.param(textwrap.dedent("\n".join(lines[4:8])), id="multiple lines"),
+        pytest.param(
+            textwrap.dedent("\n".join(lines[17:23])),
+            id="multiple lines with empty continuation line",
+        ),
     ),
 )
 def test_reformatting_func(expected):
@@ -59,3 +76,4 @@ def test_reformatting_func(expected):
 
     actual = doctest.reformatting_func(line)
     assert expected == actual
+    assert '"""' not in actual

--- a/blackdoc/tests/test_doctest.py
+++ b/blackdoc/tests/test_doctest.py
@@ -9,6 +9,19 @@ from .data.doctest import lines
 
 
 @pytest.mark.parametrize(
+    ("string", "expected"),
+    (
+        pytest.param("a", None, id="no quotes"),
+        pytest.param("'''a'''", "'''", id="single quotes"),
+        pytest.param('"""a"""', '"""', id="double quotes"),
+    ),
+)
+def test_detect_docstring_quotes(string, expected):
+    actual = doctest.detect_docstring_quotes(string)
+    assert expected == actual
+
+
+@pytest.mark.parametrize(
     "lines,expected",
     (
         pytest.param(lines[0], None, id="no_line"),
@@ -50,7 +63,8 @@ def test_detection_func(lines, expected):
     ),
 )
 def test_extraction_func(line):
-    docstring_quotes = '"""' if '"""' in line else "'''"
+    docstring_quotes = doctest.detect_docstring_quotes(line)
+
     expected = (
         {"prompt_length": doctest.prompt_length, "docstring_quotes": docstring_quotes},
         "\n".join(line.lstrip()[4:] for line in line.split("\n")),
@@ -77,11 +91,11 @@ def test_extraction_func(line):
     ),
 )
 def test_reformatting_func(expected):
-    docstring_quotes = "'''" if "'''" in expected else '"""'
+    docstring_quotes = doctest.detect_docstring_quotes(expected)
     line = "\n".join(line.lstrip()[4:] for line in expected.split("\n"))
 
     actual = doctest.reformatting_func(line, docstring_quotes)
     assert expected == actual
 
     # make sure the docstring quotes were not changed
-    assert docstring_quotes not in expected or docstring_quotes in actual
+    assert docstring_quotes is None or docstring_quotes in actual

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -5,6 +5,8 @@ v0.2 (*unreleased*)
 -------------------
 - Support the :rst:dir:`testcode`, :rst:dir:`testsetup` and
   :rst:dir:`testcleanup` directives (:pull:`39`).
+- fix working with lines containing only the prompt and avoid changing the
+  quotes of nested docstrings (:issue:`41`, :pull:`43`)
 
 
 v0.1.2 (31 August 2020)

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -3,7 +3,8 @@ Changelog
 
 v0.2 (*unreleased*)
 -------------------
-- Support the :rst:dir:`testcode`, :rst:dir:`testsetup` and :rst:dir:`testcleanup` directives.
+- Support the :rst:dir:`testcode`, :rst:dir:`testsetup` and
+  :rst:dir:`testcleanup` directives (:pull:`39`).
 
 
 v0.1.2 (31 August 2020)


### PR DESCRIPTION
As noted in #41, empty doctest lines (line which contain only the prompt / continuation prompt) were broken because `blackdoc` assumed every valid prompt to be followed by a space.

While working on this, a different and arguably more serious bug was uncovered: `black` changes the outermost docstring quotes to `"""`, unless the quoted string contains `"""`. Not considering that when applying `black` to the `doctest` code can result in `SyntaxError`s.

 - [x] Closes #41
 - [x] Tests added
 - [x] Passes `isort . && black . && flake8`
 - [ ] User visible changes (including notable bug fixes) are documented in `changelog.rst`
