### PR TITLE
read settings from a config file

### DIFF
--- a/blackdoc/__main__.py
+++ b/blackdoc/__main__.py
@@ -5,7 +5,7 @@ import sys
 import black
 
 from . import __version__, format_lines, formats
-from .blackcompat import gen_python_files
+from .blackcompat import gen_python_files, read_pyproject_toml
 
 
 def check_format_names(string):
@@ -303,6 +303,14 @@ def main():
         version=f"{program} {__version__}",
     )
     parser.add_argument(
+        "--config",
+        action="store",
+        nargs=1,
+        type=pathlib.Path,
+        default=None,
+        help="Read configuration from FILE path.",
+    )
+    parser.add_argument(
         "src",
         action="store",
         type=pathlib.Path,
@@ -310,6 +318,10 @@ def main():
         default=None,
         help="one or more paths to work on",
     )
+    args = parser.parse_args()
+    if args.config or args.src:
+        file_defaults = read_pyproject_toml(tuple(args.src), args.config)
+        parser.set_defaults(**file_defaults)
 
     args = parser.parse_args()
     sys.exit(process(args))

--- a/blackdoc/__main__.py
+++ b/blackdoc/__main__.py
@@ -5,7 +5,7 @@ import sys
 import black
 
 from . import __version__, format_lines, formats
-from .blackcompat import gen_python_files, read_pyproject_toml
+from .blackcompat import find_project_root, gen_python_files, read_pyproject_toml
 
 
 def check_format_names(string):
@@ -22,7 +22,7 @@ def check_format_names(string):
 
 
 def collect_files(src, include, exclude):
-    root = black.find_project_root(tuple(src))
+    root = find_project_root(tuple(src))
     gitignore = black.get_gitignore(root)
     report = black.Report()
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -7,6 +7,7 @@ v0.2 (*unreleased*)
   :rst:dir:`testcleanup` directives (:pull:`39`).
 - fix working with lines containing only the prompt and avoid changing the
   quotes of nested docstrings (:issue:`41`, :pull:`43`)
+- allow configuring the use of ``black`` using ``pyproject.toml`` (:issue:`40`, :pull:`45`)
 
 
 v0.1.2 (31 August 2020)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,3 +3,6 @@ requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
+
+[tool.isort]
+profile = "black"


### PR DESCRIPTION
This changes the CLI to read default configuration settings from a user provided config file or the project's `pyproject.toml` (if it exists).

For that to work, we have to run the `argparse` parser twice. Should we switch to `click`, which is used by `black`?

 - [x] Closes #40
 - [ ] Tests added
 - [x] Passes `isort . && black . && flake8`
 - [x] User visible changes (including notable bug fixes) are documented in `changelog.rst`
 - [ ] New features are documented in the docs