### PR TITLE
Support a blackdoc section in pyproject.toml

### DIFF
--- a/blackdoc/blackcompat.py
+++ b/blackdoc/blackcompat.py
@@ -61,7 +61,10 @@ def parse_pyproject_toml(path_config):
     If parsing fails, will raise a toml.TomlDecodeError
     """
     pyproject_toml = toml.load(path_config)
-    config = pyproject_toml.get("tool", {}).get("black", {})
+    black_config = pyproject_toml.get("tool", {}).get("black", {})
+    blackdoc_config = pyproject_toml.get("tool", {}).get("blackdoc", {})
+    config = {**black_config, **blackdoc_config}
+
     return {k.replace("--", "").replace("-", "_"): v for k, v in config.items()}
 
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -7,7 +7,8 @@ v0.2 (*unreleased*)
   :rst:dir:`testcleanup` directives (:pull:`39`).
 - fix working with lines containing only the prompt and avoid changing the
   quotes of nested docstrings (:issue:`41`, :pull:`43`)
-- allow configuring the use of ``black`` using ``pyproject.toml`` (:issue:`40`, :pull:`45`)
+- allow configuring ``blackdoc`` using ``pyproject.toml``
+  (:issue:`40`, :pull:`45`, :pull:`47`)
 
 
 v0.1.2 (31 August 2020)


### PR DESCRIPTION
Extends #45 to also allow setting the desired formats.

 - [x] Passes `isort . && black . && flake8`
 - [x] User visible changes (including notable bug fixes) are documented in `changelog.rst`
