### PR TITLE
add a force exclude option

### DIFF
--- a/blackdoc/__main__.py
+++ b/blackdoc/__main__.py
@@ -37,7 +37,25 @@ def collect_files(src, include, exclude, force_exclude):
                 report,
                 gitignore,
             )
-        elif path.is_file() or str(path) == "-":
+        elif str(path) == "-":
+            yield path
+        elif path.is_file():
+            normalized_path = black.normalize_path_maybe_ignore(path, root, report)
+            if normalized_path is None:
+                continue
+
+            normalized_path = "/" + normalized_path
+            # Hard-exclude any files that matches the `--force-exclude` regex.
+            if force_exclude:
+                force_exclude_match = force_exclude.search(normalized_path)
+            else:
+                force_exclude_match = None
+            if force_exclude_match and force_exclude_match.group(0):
+                report.path_ignored(
+                    path, "matches the --force-exclude regular expression"
+                )
+                continue
+
             yield path
         else:
             print(f"invalid path: {path}", file=sys.stderr)
@@ -171,14 +189,13 @@ def process(args):
         return 2
 
     try:
+        force_exclude = getattr(args, "force_exclude", "")
         force_exclude_regex = (
-            black.re_compile_maybe_verbose(args.force_exclude)
-            if args.force_exclude
-            else None
+            black.re_compile_maybe_verbose(force_exclude) if force_exclude else None
         )
     except black.re.error:
         print(
-            f"Invalid regular expression for force_exclude given: {args.force_exclude!r}",
+            f"Invalid regular expression for force_exclude given: {force_exclude!r}",
             file=sys.stderr,
         )
         return 2

--- a/blackdoc/__main__.py
+++ b/blackdoc/__main__.py
@@ -21,12 +21,10 @@ def check_format_names(string):
     return names
 
 
-def collect_files(src, include, exclude):
+def collect_files(src, include, exclude, force_exclude):
     root = find_project_root(tuple(src))
     gitignore = black.get_gitignore(root)
     report = black.Report()
-
-    force_exclude = ""
 
     for path in src:
         if path.is_dir():
@@ -172,7 +170,22 @@ def process(args):
         )
         return 2
 
-    sources = set(collect_files(args.src, include_regex, exclude_regex))
+    try:
+        force_exclude_regex = (
+            black.re_compile_maybe_verbose(args.force_exclude)
+            if args.force_exclude
+            else None
+        )
+    except black.re.error:
+        print(
+            f"Invalid regular expression for force_exclude given: {args.force_exclude!r}",
+            file=sys.stderr,
+        )
+        return 2
+
+    sources = set(
+        collect_files(args.src, include_regex, exclude_regex, force_exclude_regex)
+    )
     if len(sources) == 0:
         print("No files are present to be formatted. Nothing to do 😴")
         return 0

--- a/blackdoc/__main__.py
+++ b/blackdoc/__main__.py
@@ -280,6 +280,17 @@ def main():
         ),
     )
     parser.add_argument(
+        "--force-exclude",
+        metavar="TEXT",
+        type=str,
+        default=argparse.SUPPRESS,
+        help=(
+            "Like --exclude, but files and directories"
+            " matching this regex will be excluded even"
+            " when they are passed explicitly as arguments"
+        ),
+    )
+    parser.add_argument(
         "--formats",
         metavar="FMT[,FMT[,FMT...]]",
         type=check_format_names,

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -9,6 +9,7 @@ v0.2 (*unreleased*)
   quotes of nested docstrings (:issue:`41`, :pull:`43`)
 - Allow configuring ``blackdoc`` using ``pyproject.toml``
   (:issue:`40`, :pull:`45`, :pull:`47`)
+- Add a ``force-exclude`` option (:pull:`49`)
 
 
 v0.1.2 (31 August 2020)

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -5,15 +5,15 @@ v0.2 (*unreleased*)
 -------------------
 - Support the :rst:dir:`testcode`, :rst:dir:`testsetup` and
   :rst:dir:`testcleanup` directives (:pull:`39`).
-- fix working with lines containing only the prompt and avoid changing the
+- Fix working with lines containing only the prompt and avoid changing the
   quotes of nested docstrings (:issue:`41`, :pull:`43`)
-- allow configuring ``blackdoc`` using ``pyproject.toml``
+- Allow configuring ``blackdoc`` using ``pyproject.toml``
   (:issue:`40`, :pull:`45`, :pull:`47`)
 
 
 v0.1.2 (31 August 2020)
 -----------------------
-- keep compatibility with ``black`` 20.8b1 (:pull:`34`)
+- Keep compatibility with ``black`` 20.8b1 (:pull:`34`)
 
 v0.1.1 (14 June 2020)
 ---------------------


### PR DESCRIPTION
Related to #33. This option is solely to mirror `black`'s CLI.

Edit: turns out this is for files that were explicitly listed in the command line:
```
python -m blackdoc --check --force-exclude "to_format.py" . to_format.py
```
would not reformat `to_format.py` while `--exclude` would only filter the `to_format.py` from reformatting `.`

 - [ ] Tests added
 - [x] Passes `isort . && black . && flake8`
 - [x] User visible changes (including notable bug fixes) are documented in `changelog.rst`
 - [ ] New features are documented in the docs