### PR TITLE
add a python 3.9 CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.6, 3.7]
+        python-version: [3.6, 3.7, 3.9]
         include:
           - python-version: 3.8
             dependencies: ""


### PR DESCRIPTION
Python 3.9 has been out for a few weeks so it's time to start testing with it.