### PR TITLE
Update the linter configuration

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -57,7 +57,7 @@ jobs:
       run: python -m pip list
 
     - name: run isort
-      run: python -m isort -rc --check .
+      run: python -m isort --check .
 
   black:
     name: black

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -57,7 +57,7 @@ jobs:
       run: python -m pip list
 
     - name: run isort
-      run: python -m isort --check .
+      run: python -m isort --diff --color .
 
   black:
     name: black
@@ -82,4 +82,4 @@ jobs:
       run: python -m pip list
 
     - name: run black
-      run: python -m black --check .
+      run: python -m black --diff --color .

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
     Topic :: Documentation
     Topic :: Software Development :: Documentation
     Topic :: Software Development :: Libraries :: Python Modules

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,4 +47,3 @@ ignore =
     W503
 exclude=
     .eggs
-    doc

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,14 +36,10 @@ console_scripts =
 
 [flake8]
 ignore =
-    # whitespace before ':' - doesn't work well with black
-    E203
-    E402
-    # line too long - let black worry about that
-    E501
-    # do not assign a lambda expression, use a def
-    E731
-    # line break before binary operator
-    W503
+    E203 # whitespace before ':' - doesn't work well with black
+    E402 # module level import not at top of file
+    E501 # line too long - let black worry about that
+    E731 # do not assign a lambda expression, use a def
+    W503 # line break before binary operator
 exclude=
     .eggs


### PR DESCRIPTION
This is mostly just a clean-up of the `flake8` config, and a switch to reporting changed files with diffs. The missing trove classifier should have been added in #55.