### PR TITLE
Skip string normalization

### DIFF
--- a/blackdoc/__main__.py
+++ b/blackdoc/__main__.py
@@ -272,7 +272,7 @@ def process(args):
     mode = black.FileMode(
         line_length=args.line_length,
         target_versions=target_versions,
-        skip_string_normalization=args.strip_string_normalization,
+        string_normalization=not args.skip_string_normalization,
     )
 
     actions = {

--- a/blackdoc/__main__.py
+++ b/blackdoc/__main__.py
@@ -272,6 +272,7 @@ def process(args):
     mode = black.FileMode(
         line_length=args.line_length,
         target_versions=target_versions,
+        skip_string_normalization=args.strip_string_normalization,
     )
 
     actions = {
@@ -421,6 +422,13 @@ def main():
             "This option also affects formats explicitly set."
         ),
         default=argparse.SUPPRESS,
+    )
+    parser.add_argument(
+        "-S",
+        "--skip-string-normalization",
+        dest="skip_string_normalization",
+        action="store_true",
+        help="Don't normalize string quotes or prefixes.",
     )
     parser.add_argument(
         "--version",

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 v0.3 (*unreleased*)
 -------------------
 - add diff and color diff modes (:pull:`56`)
+- support `black`'s string normalization option (:pull:`59`)
 
 
 v0.2 (01 October 2020)

--- a/doc/options.rst
+++ b/doc/options.rst
@@ -40,6 +40,9 @@ line_length
     ``-l`` or ``--line-length``, ``int``. How many characters per line to allow. By
     default, set to 88.
 
+string normalization
+    ``-S`` or ``--skip-string-normalization``. If enabled, skips the string normalization.
+
 include
     ``--include``, ``str``. A regular expression that matches files and
     directories that should be included on recursive searches. An empty value

--- a/doc/options.rst
+++ b/doc/options.rst
@@ -40,7 +40,7 @@ line_length
     ``-l`` or ``--line-length``, ``int``. How many characters per line to allow. By
     default, set to 88.
 
-string normalization
+skip_string_normalization
     ``-S`` or ``--skip-string-normalization``. If enabled, skips the string normalization.
 
 include


### PR DESCRIPTION
This adds the string normalization option `black` offers.

 - [x] Passes `isort . && black . && flake8`
 - [ ] User visible changes (including notable bug fixes) are documented in `changelog.rst`
 - [ ] New features are documented in the docs