### PR TITLE
Color output

### DIFF
--- a/blackdoc/__main__.py
+++ b/blackdoc/__main__.py
@@ -123,13 +123,13 @@ def color_diff(contents):
     lines = contents.split("\n")
     for i, line in enumerate(lines):
         if line.startswith("+++") or line.startswith("---"):
-            line = "\033[1;37m" + line + "\033[0m"  # bold white, reset
+            line = white(line, bold=True)  # bold white, reset
         elif line.startswith("@@"):
-            line = "\033[36m" + line + "\033[0m"  # cyan, reset
+            line = cyan(line)  # cyan, reset
         elif line.startswith("+"):
-            line = "\033[32m" + line + "\033[0m"  # green, reset
+            line = green(line)  # green, reset
         elif line.startswith("-"):
-            line = "\033[31m" + line + "\033[0m"  # red, reset
+            line = red(line)  # red, reset
         lines[i] = line
     return "\n".join(lines)
 

--- a/blackdoc/__main__.py
+++ b/blackdoc/__main__.py
@@ -70,6 +70,54 @@ def collect_files(src, include, exclude, force_exclude):
             print(f"invalid path: {path}", file=sys.stderr)
 
 
+def white(string, bold=False):
+    color_code = "37"
+    bold_code = "1"
+    reset_code = "0"
+
+    codes = [color_code]
+    if bold:
+        codes.insert(0, bold_code)
+
+    return f"\033[{';'.join(codes)}m{string}\033[{reset_code}m"
+
+
+def cyan(string, bold=False):
+    color_code = "36"
+    bold_code = "1"
+    reset_code = "0"
+
+    codes = [color_code]
+    if bold:
+        codes.insert(0, bold_code)
+
+    return f"\033[{';'.join(codes)}m{string}\033[{reset_code}m"
+
+
+def green(string, bold=False):
+    color_code = "32"
+    bold_code = "1"
+    reset_code = "0"
+
+    codes = [color_code]
+    if bold:
+        codes.insert(0, bold_code)
+
+    return f"\033[{';'.join(codes)}m{string}\033[{reset_code}m"
+
+
+def red(string, bold=False):
+    color_code = "31"
+    bold_code = "1"
+    reset_code = "0"
+
+    codes = [color_code]
+    if bold:
+        codes.insert(0, bold_code)
+
+    return f"\033[{';'.join(codes)}m{string}\033[{reset_code}m"
+
+
 def color_diff(contents):
     """Inject the ANSI color codes to the diff."""
     lines = contents.split("\n")

--- a/blackdoc/__main__.py
+++ b/blackdoc/__main__.py
@@ -167,13 +167,13 @@ def format_and_overwrite(path, mode):
         if new_content == content:
             result = "unchanged"
         else:
-            print(f"reformatted {path}")
+            print(white(f"reformatted {path}"), bold=True)
             result = "reformatted"
 
         with open(path, "w", encoding=encoding, newline=newline) as f:
             f.write(new_content)
     except black.InvalidInput as e:
-        print(f"error: cannot format {path.absolute()}: {e}")
+        print(red(f"error: cannot format {path.absolute()}: {e}"))
         result = "error"
 
     return result
@@ -191,14 +191,14 @@ def format_and_check(path, mode, diff=False, color=False):
         if new_content == content:
             result = "unchanged"
         else:
-            print(f"would reformat {path}")
+            print(white(f"would reformat {path}", bold=True))
 
             if diff:
                 print(unified_diff(content, new_content, path, color))
 
             result = "reformatted"
     except black.InvalidInput as e:
-        print(f"error: cannot format {path.absolute()}: {e}")
+        print(red(f"error: cannot format {path.absolute()}: {e}"))
         result = "error"
 
     return result
@@ -210,13 +210,15 @@ def report_changes(n_reformatted, n_unchanged, n_error):
 
     reports = []
     if n_reformatted > 0:
-        reports.append(f"{n_reformatted} {noun(n_reformatted)} reformatted")
+        reports.append(
+            white(f"{n_reformatted} {noun(n_reformatted)} reformatted", bold=True)
+        )
 
     if n_unchanged > 0:
-        reports.append(f"{n_unchanged} {noun(n_unchanged)} left unchanged")
+        reports.append(white(f"{n_unchanged} {noun(n_unchanged)} left unchanged"))
 
     if n_error > 0:
-        reports.append(f"{n_error} {noun(n_error)} fails to reformat")
+        reports.append(red(f"{n_error} {noun(n_error)} fails to reformat"))
 
     return ", ".join(reports) + "."
 
@@ -227,13 +229,19 @@ def report_possible_changes(n_reformatted, n_unchanged, n_error):
 
     reports = []
     if n_reformatted > 0:
-        reports.append(f"{n_reformatted} {noun(n_reformatted)} would be reformatted")
+        reports.append(
+            white(
+                f"{n_reformatted} {noun(n_reformatted)} would be reformatted", bold=True
+            )
+        )
 
     if n_unchanged > 0:
-        reports.append(f"{n_unchanged} {noun(n_unchanged)} would be left unchanged")
+        reports.append(
+            white(f"{n_unchanged} {noun(n_unchanged)} would be left unchanged")
+        )
 
     if n_error > 0:
-        reports.append(f"{n_error} {noun(n_error)} would fail to reformat")
+        reports.append(red(f"{n_error} {noun(n_error)} would fail to reformat"))
 
     return ", ".join(reports) + "."
 
@@ -255,7 +263,7 @@ def statistics(sources):
 
 def process(args):
     if not args.src:
-        print("No Path provided. Nothing to do 😴")
+        print(white("No Path provided. Nothing to do 😴", bold=True))
         return 0
 
     selected_formats = getattr(args, "formats", None)
@@ -272,7 +280,7 @@ def process(args):
         include_regex = black.re_compile_maybe_verbose(args.include)
     except black.re.error:
         print(
-            f"Invalid regular expression for include given: {args.include!r}",
+            red(f"Invalid regular expression for include given: {args.include!r}"),
             file=sys.stderr,
         )
         return 2
@@ -281,7 +289,7 @@ def process(args):
         exclude_regex = black.re_compile_maybe_verbose(args.exclude)
     except black.re.error:
         print(
-            f"Invalid regular expression for exclude given: {args.exclude!r}",
+            red(f"Invalid regular expression for exclude given: {args.exclude!r}"),
             file=sys.stderr,
         )
         return 2
@@ -293,7 +301,9 @@ def process(args):
         )
     except black.re.error:
         print(
-            f"Invalid regular expression for force_exclude given: {force_exclude!r}",
+            red(
+                f"Invalid regular expression for force_exclude given: {force_exclude!r}"
+            ),
             file=sys.stderr,
         )
         return 2
@@ -302,7 +312,7 @@ def process(args):
         collect_files(args.src, include_regex, exclude_regex, force_exclude_regex)
     )
     if len(sources) == 0:
-        print("No files are present to be formatted. Nothing to do 😴")
+        print(white("No files are present to be formatted. Nothing to do 😴", bold=True))
         return 0
 
     target_versions = set(
@@ -342,7 +352,9 @@ def process(args):
     else:
         return_code = 0
 
-    print("Oh no! 💥 💔 💥" if return_code else "All done! ✨ 🍰 ✨")
+    reformatted_message = white("Oh no! 💥 💔 💥", bold=True)
+    no_reformatting_message = white("All done! ✨ 🍰 ✨", bold=True)
+    print(reformatted_message if return_code else no_reformatting_message)
     print(report)
     return return_code
 

--- a/blackdoc/__main__.py
+++ b/blackdoc/__main__.py
@@ -3,12 +3,18 @@ import datetime
 import difflib
 import pathlib
 import sys
-from contextlib import contextmanager
 
 import black
 
 from . import __version__, format_lines, formats
 from .blackcompat import find_project_root, gen_python_files, read_pyproject_toml
+
+try:
+    import colorama
+
+    colorama.init()
+except ImportError:
+    pass
 
 
 def check_format_names(string):
@@ -99,20 +105,6 @@ def unified_diff(a, b, path, color):
         diff = color_diff(diff)
 
     return diff
-
-
-@contextmanager
-def maybe_guard_stdout():
-    try:
-        import colorama
-
-        colorama.init()
-
-        yield
-
-        colorama.deinit()
-    finally:
-        pass
 
 
 def format_and_overwrite(path, mode):

--- a/blackdoc/__main__.py
+++ b/blackdoc/__main__.py
@@ -70,7 +70,7 @@ def collect_files(src, include, exclude, force_exclude):
             print(f"invalid path: {path}", file=sys.stderr)
 
 
-def color(string, fg=None, bold=False):
+def colorize(string, fg=None, bold=False):
     foreground_colors = {
         "white": 37,
         "cyan": 36,
@@ -95,13 +95,13 @@ def color_diff(contents):
     lines = contents.split("\n")
     for i, line in enumerate(lines):
         if line.startswith("+++") or line.startswith("---"):
-            line = color(line, fg="white", bold=True)  # bold white, reset
+            line = colorize(line, fg="white", bold=True)  # bold white, reset
         elif line.startswith("@@"):
-            line = color(line, fg="cyan")  # cyan, reset
+            line = colorize(line, fg="cyan")  # cyan, reset
         elif line.startswith("+"):
-            line = color(line, fg="green")  # green, reset
+            line = colorize(line, fg="green")  # green, reset
         elif line.startswith("-"):
-            line = color(line, fg="red")  # red, reset
+            line = colorize(line, fg="red")  # red, reset
         lines[i] = line
     return "\n".join(lines)
 
@@ -139,13 +139,13 @@ def format_and_overwrite(path, mode):
         if new_content == content:
             result = "unchanged"
         else:
-            print(color(f"reformatted {path}", fg="white", bold=True))
+            print(colorize(f"reformatted {path}", fg="white", bold=True))
             result = "reformatted"
 
         with open(path, "w", encoding=encoding, newline=newline) as f:
             f.write(new_content)
     except black.InvalidInput as e:
-        print(color(f"error: cannot format {path.absolute()}: {e}", fg="red"))
+        print(colorize(f"error: cannot format {path.absolute()}: {e}", fg="red"))
         result = "error"
 
     return result
@@ -163,14 +163,14 @@ def format_and_check(path, mode, diff=False, color=False):
         if new_content == content:
             result = "unchanged"
         else:
-            print(color(f"would reformat {path}", fg="white", bold=True))
+            print(colorize(f"would reformat {path}", fg="white", bold=True))
 
             if diff:
                 print(unified_diff(content, new_content, path, color))
 
             result = "reformatted"
     except black.InvalidInput as e:
-        print(color(f"error: cannot format {path.absolute()}: {e}", fg="red"))
+        print(colorize(f"error: cannot format {path.absolute()}: {e}", fg="red"))
         result = "error"
 
     return result
@@ -183,7 +183,7 @@ def report_changes(n_reformatted, n_unchanged, n_error):
     reports = []
     if n_reformatted > 0:
         reports.append(
-            color(
+            colorize(
                 f"{n_reformatted} {noun(n_reformatted)} reformatted",
                 fg="white",
                 bold=True,
@@ -192,11 +192,13 @@ def report_changes(n_reformatted, n_unchanged, n_error):
 
     if n_unchanged > 0:
         reports.append(
-            color(f"{n_unchanged} {noun(n_unchanged)} left unchanged", fg="white")
+            colorize(f"{n_unchanged} {noun(n_unchanged)} left unchanged", fg="white")
         )
 
     if n_error > 0:
-        reports.append(color(f"{n_error} {noun(n_error)} fails to reformat", fg="red"))
+        reports.append(
+            colorize(f"{n_error} {noun(n_error)} fails to reformat", fg="red")
+        )
 
     return ", ".join(reports) + "."
 
@@ -208,7 +210,7 @@ def report_possible_changes(n_reformatted, n_unchanged, n_error):
     reports = []
     if n_reformatted > 0:
         reports.append(
-            color(
+            colorize(
                 f"{n_reformatted} {noun(n_reformatted)} would be reformatted",
                 fg="white",
                 bold=True,
@@ -217,14 +219,14 @@ def report_possible_changes(n_reformatted, n_unchanged, n_error):
 
     if n_unchanged > 0:
         reports.append(
-            color(
+            colorize(
                 f"{n_unchanged} {noun(n_unchanged)} would be left unchanged", fg="white"
             )
         )
 
     if n_error > 0:
         reports.append(
-            color(f"{n_error} {noun(n_error)} would fail to reformat", fg="red")
+            colorize(f"{n_error} {noun(n_error)} would fail to reformat", fg="red")
         )
 
     return ", ".join(reports) + "."
@@ -247,7 +249,7 @@ def statistics(sources):
 
 def process(args):
     if not args.src:
-        print(color("No Path provided. Nothing to do 😴", fg="white", bold=True))
+        print(colorize("No Path provided. Nothing to do 😴", fg="white", bold=True))
         return 0
 
     selected_formats = getattr(args, "formats", None)
@@ -264,7 +266,7 @@ def process(args):
         include_regex = black.re_compile_maybe_verbose(args.include)
     except black.re.error:
         print(
-            color(
+            colorize(
                 f"Invalid regular expression for include given: {args.include!r}",
                 fg="red",
             ),
@@ -276,7 +278,7 @@ def process(args):
         exclude_regex = black.re_compile_maybe_verbose(args.exclude)
     except black.re.error:
         print(
-            color(
+            colorize(
                 f"Invalid regular expression for exclude given: {args.exclude!r}",
                 fg="red",
             ),
@@ -291,7 +293,7 @@ def process(args):
         )
     except black.re.error:
         print(
-            color(
+            colorize(
                 f"Invalid regular expression for force_exclude given: {force_exclude!r}",
                 fg="red",
             ),
@@ -304,7 +306,7 @@ def process(args):
     )
     if len(sources) == 0:
         print(
-            color(
+            colorize(
                 "No files are present to be formatted. Nothing to do 😴",
                 fg="white",
                 bold=True,
@@ -349,8 +351,8 @@ def process(args):
     else:
         return_code = 0
 
-    reformatted_message = color("Oh no! 💥 💔 💥", fg="white", bold=True)
-    no_reformatting_message = color("All done! ✨ 🍰 ✨", fg="white", bold=True)
+    reformatted_message = colorize("Oh no! 💥 💔 💥", fg="white", bold=True)
+    no_reformatting_message = colorize("All done! ✨ 🍰 ✨", fg="white", bold=True)
     print(reformatted_message if return_code else no_reformatting_message)
     print(report)
     return return_code

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -5,6 +5,7 @@ v0.3 (*unreleased*)
 -------------------
 - add diff and color diff modes (:pull:`56`)
 - support `black`'s string normalization option (:pull:`59`)
+- add colors to the output (:pull:`60`)
 
 
 v0.2 (01 October 2020)


### PR DESCRIPTION
This colors the output to make the CLI look even more like `black`. One remaining issue is how to disable the colors in certain situations (e.g. terminal emulators that don't support colors), but that's something to be figured out once someone actually bumps into that. Also, `black` doesn't seem to do that, either...

 - [x] Closes #33
 - [x] Passes `isort . && black . && flake8`
 - [x] User visible changes (including notable bug fixes) are documented in `changelog.rst`