### PR TITLE
sort the detected files

### DIFF
--- a/blackdoc/__main__.py
+++ b/blackdoc/__main__.py
@@ -333,7 +333,7 @@ def process(args):
     action = actions.get(args.action)
 
     changed_sources = {
-        source: action(source, mode, **action_kwargs) for source in sources
+        source: action(source, mode, **action_kwargs) for source in sorted(sources)
     }
     n_reformatted, n_unchanged, n_error = statistics(changed_sources)
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -6,6 +6,7 @@ v0.3 (*unreleased*)
 - add diff and color diff modes (:pull:`56`)
 - support `black`'s string normalization option (:pull:`59`)
 - add colors to the output (:pull:`60`)
+- make the order of the printed files predictable (:pull:`61`)
 
 
 v0.2 (01 October 2020)


### PR DESCRIPTION
The detected files are passed through a `set`, which means that the order changes on each run. This sorts the files before actually working with them.

 - [x] Passes `isort . && black . && flake8`
 - [x] User visible changes (including notable bug fixes) are documented in `changelog.rst`