### PR TITLE
Keep newline after block

### DIFF
--- a/blackdoc/formats/doctest.py
+++ b/blackdoc/formats/doctest.py
@@ -10,6 +10,7 @@ prompt_re = re.compile(r"(>>> ?)")
 continuation_prompt = "..."
 continuation_prompt_re = re.compile(r"(\.\.\. ?)")
 include_pattern = r"\.pyi?$"
+block_start_re = re.compile(r"^[^:]+:(\s*#.*)?$")
 
 
 def continuation_lines(lines):
@@ -102,7 +103,11 @@ def reformatting_func(line, docstring_quotes):
 
         return " ".join([prompt, line])
 
-    lines = iter(line.split("\n"))
+    lines = line.rstrip().split("\n")
+    if block_start_re.match(lines[0]):
+        lines.append("")
+
+    lines = iter(lines)
 
     reformatted = "\n".join(
         itertools.chain(

--- a/blackdoc/tests/data/__init__.py
+++ b/blackdoc/tests/data/__init__.py
@@ -9,7 +9,7 @@ def from_dict(labels):
     return line_ranges, line_labels
 
 
-def print_line_with_range(name, range_, unit):
+def format_line_with_range(name, range_, unit):
     min_, max_ = range_
     line_numbers = range(min_ + 1, max_ + 1)
 
@@ -19,7 +19,8 @@ def print_line_with_range(name, range_, unit):
     end_group = "┘"
 
     lines = unit.split("\n")
-    for index, (lineno, line) in enumerate(zip(line_numbers, lines)):
+
+    def determine_classifier(index):
         if max_ - min_ == 1:
             classifier = no_group
         elif index == 0:
@@ -29,9 +30,19 @@ def print_line_with_range(name, range_, unit):
         else:
             classifier = mid_group
 
-        print(f"{name:>8s} {classifier} → {lineno:02d}: {line}")
+        return classifier
+
+    return "\n".join(
+        f"{name:>8s} {determine_classifier(index)} → {lineno:02d}: {line}"
+        for index, (lineno, line) in enumerate(zip(line_numbers, lines))
+    )
+
+
+def format_classification(labeled):
+    return "\n".join(
+        format_line_with_range(range, name, unit) for name, range, unit in labeled
+    )
 
 
 def print_classification(labeled):
-    for name, range, unit in labeled:
-        print_line_with_range(range, name, unit)
+    print(format_classification(labeled))

--- a/blackdoc/tests/data/doctest.py
+++ b/blackdoc/tests/data/doctest.py
@@ -24,6 +24,11 @@ docstring = """ a function to open files
     ...     '''
     ...     pass
     >>>
+
+    >>> if myfunc2(2, 1) is not None:
+    ...     print("caught")
+    >>> a = 2
+    ...
 """
 lines = docstring.split("\n")
 labels = {
@@ -44,5 +49,8 @@ labels = {
     (18, 24): "doctest",
     24: "doctest",
     25: "none",
+    (26, 28): "doctest",
+    (28, 30): "doctest",
+    30: "none",
 }
 line_ranges, line_labels = from_dict(labels)

--- a/blackdoc/tests/data/doctest.py
+++ b/blackdoc/tests/data/doctest.py
@@ -54,3 +54,59 @@ labels = {
     30: "none",
 }
 line_ranges, line_labels = from_dict(labels)
+
+expected = """ a function to open files
+
+    with a very long description
+
+    >>> file = open(
+    ...     "very_long_filepath",
+    ...     mode="a",
+    ... )
+    >>> file
+    <_io.TextIOWrapper name='very_long_filepath' mode='w' encoding='UTF-8'>
+
+    text after the first example, spanning
+    multiple lines
+
+    >>> file.closed
+    False
+
+    >>> def myfunc2(arg1, arg2):
+    ...     '''Docstring for function myfunc2 in docstring
+    ...
+    ...     More description of the function.
+    ...     '''
+    ...     pass
+    ...
+    >>>
+
+    >>> if myfunc2(2, 1) is not None:
+    ...     print("caught")
+    ...
+    >>> a = 2
+"""
+expected_lines = expected.split("\n")
+expected_labels = {
+    1: "none",
+    2: "none",
+    3: "none",
+    4: "none",
+    (5, 9): "doctest",
+    9: "doctest",
+    10: "none",
+    11: "none",
+    12: "none",
+    13: "none",
+    14: "none",
+    15: "doctest",
+    16: "none",
+    17: "none",
+    (18, 25): "doctest",
+    25: "doctest",
+    26: "none",
+    (27, 30): "doctest",
+    30: "doctest",
+    31: "none",
+}
+expected_line_ranges, expected_line_labels = from_dict(expected_labels)

--- a/blackdoc/tests/data/doctest.py
+++ b/blackdoc/tests/data/doctest.py
@@ -17,11 +17,11 @@ docstring = """ a function to open files
     >>> file.closed
     False
 
-    >>> def myfunc2(arg1, arg2):
-    ...     '''Docstring for function myfunc2 in docstring
+    >>> ''' arbitrary triple-quoted string
     ...
-    ...     More description of the function.
-    ...     '''
+    ... with a empty continuation line
+    ... '''
+    >>> def myfunc2(arg1, arg2):
     ...     pass
     >>>
 
@@ -46,7 +46,8 @@ labels = {
     15: "doctest",
     16: "none",
     17: "none",
-    (18, 24): "doctest",
+    (18, 22): "doctest",
+    (22, 24): "doctest",
     24: "doctest",
     25: "none",
     (26, 28): "doctest",
@@ -72,11 +73,11 @@ expected = """ a function to open files
     >>> file.closed
     False
 
-    >>> def myfunc2(arg1, arg2):
-    ...     '''Docstring for function myfunc2 in docstring
+    >>> ''' arbitrary triple-quoted string
     ...
-    ...     More description of the function.
-    ...     '''
+    ... with a empty continuation line
+    ... '''
+    >>> def myfunc2(arg1, arg2):
     ...     pass
     ...
     >>>
@@ -102,7 +103,8 @@ expected_labels = {
     15: "doctest",
     16: "none",
     17: "none",
-    (18, 25): "doctest",
+    (18, 22): "doctest",
+    (22, 25): "doctest",
     25: "doctest",
     26: "none",
     (27, 30): "doctest",

--- a/blackdoc/tests/test_doctest.py
+++ b/blackdoc/tests/test_doctest.py
@@ -5,7 +5,7 @@ import pytest
 
 from blackdoc.formats import doctest
 
-from .data.doctest import lines
+from .data.doctest import expected_lines, lines
 
 
 @pytest.mark.parametrize(
@@ -75,26 +75,41 @@ def test_extraction_func(line):
 
 
 @pytest.mark.parametrize(
-    "expected",
+    ["code_unit", "expected"],
     (
-        pytest.param(textwrap.dedent(lines[8]), id="single line"),
-        pytest.param(textwrap.dedent(lines[23]), id="single empty line"),
-        pytest.param(textwrap.dedent("\n".join(lines[4:8])), id="multiple lines"),
         pytest.param(
-            textwrap.dedent("\n".join(lines[17:23])),
+            textwrap.dedent(lines[8])[4:],
+            textwrap.dedent(expected_lines[8]),
+            id="single line",
+        ),
+        pytest.param(
+            textwrap.dedent(lines[23])[4:],
+            textwrap.dedent(expected_lines[24]),
+            id="single empty line",
+        ),
+        pytest.param(
+            "\n".join(line.lstrip()[4:] for line in lines[4:8]),
+            "\n".join(line.lstrip() for line in expected_lines[4:8]),
+            id="multiple lines",
+        ),
+        pytest.param(
+            "\n".join(line.lstrip()[4:] for line in lines[17:23]),
+            "\n".join(line.lstrip() for line in expected_lines[17:24]),
             id="multiple lines with empty continuation line",
         ),
         pytest.param(
-            textwrap.dedent("\n".join(lines[17:23]).replace("'''", '"""')),
+            "\n".join(line.lstrip()[4:] for line in lines[17:23]).replace("'''", '"""'),
+            "\n".join(line.lstrip() for line in expected_lines[17:24]).replace(
+                "'''", '"""'
+            ),
             id="multiple lines with inverted docstring quotes",
         ),
     ),
 )
-def test_reformatting_func(expected):
-    docstring_quotes = doctest.detect_docstring_quotes(expected)
-    line = "\n".join(line.lstrip()[4:] for line in expected.split("\n"))
+def test_reformatting_func(code_unit, expected):
+    docstring_quotes = doctest.detect_docstring_quotes(code_unit)
 
-    actual = doctest.reformatting_func(line, docstring_quotes)
+    actual = doctest.reformatting_func(code_unit, docstring_quotes)
     assert expected == actual
 
     # make sure the docstring quotes were not changed

--- a/blackdoc/tests/test_doctest.py
+++ b/blackdoc/tests/test_doctest.py
@@ -74,35 +74,49 @@ def test_extraction_func(line):
     assert expected == actual
 
 
+def prepare_lines(lines, remove_prompt=False):
+    dedented = (line.lstrip() for line in more_itertools.always_iterable(lines))
+    prepared = dedented if not remove_prompt else (line[4:] for line in dedented)
+    return "\n".join(prepared)
+
+
 @pytest.mark.parametrize(
     ["code_unit", "expected"],
     (
         pytest.param(
-            textwrap.dedent(lines[8])[4:],
-            textwrap.dedent(expected_lines[8]),
+            prepare_lines(lines[8], remove_prompt=True),
+            prepare_lines(expected_lines[8]),
             id="single line",
         ),
         pytest.param(
-            textwrap.dedent(lines[23])[4:],
-            textwrap.dedent(expected_lines[24]),
+            prepare_lines(lines[23], remove_prompt=True),
+            prepare_lines(expected_lines[24]),
             id="single empty line",
         ),
         pytest.param(
-            "\n".join(line.lstrip()[4:] for line in lines[4:8]),
-            "\n".join(line.lstrip() for line in expected_lines[4:8]),
+            prepare_lines(lines[4:8], remove_prompt=True),
+            prepare_lines(expected_lines[4:8]),
             id="multiple lines",
         ),
         pytest.param(
-            "\n".join(line.lstrip()[4:] for line in lines[17:23]),
-            "\n".join(line.lstrip() for line in expected_lines[17:24]),
+            prepare_lines(lines[17:21], remove_prompt=True),
+            prepare_lines(expected_lines[17:21]),
             id="multiple lines with empty continuation line",
         ),
         pytest.param(
-            "\n".join(line.lstrip()[4:] for line in lines[17:23]).replace("'''", '"""'),
-            "\n".join(line.lstrip() for line in expected_lines[17:24]).replace(
-                "'''", '"""'
-            ),
+            prepare_lines(lines[17:21], remove_prompt=True).replace("'''", '"""'),
+            prepare_lines(expected_lines[17:21]).replace("'''", '"""'),
             id="multiple lines with inverted docstring quotes",
+        ),
+        pytest.param(
+            prepare_lines(lines[21:23], remove_prompt=True),
+            prepare_lines(expected_lines[21:24]),
+            id="trailing newline at the end of a block",
+        ),
+        pytest.param(
+            prepare_lines(lines[27:29], remove_prompt=True),
+            prepare_lines(expected_lines[29]),
+            id="trailing newline at the end of a normal line",
         ),
     ),
 )

--- a/blackdoc/tests/test_doctest.py
+++ b/blackdoc/tests/test_doctest.py
@@ -35,8 +35,8 @@ def test_detect_docstring_quotes(string, expected):
             lines[23], ((1, 2), doctest.name, lines[23]), id="single empty line"
         ),
         pytest.param(
-            lines[17:23],
-            ((1, 7), doctest.name, "\n".join(lines[17:23])),
+            lines[17:21],
+            ((1, 5), doctest.name, "\n".join(lines[17:21])),
             id="multiple lines with empty continuation line",
         ),
     ),

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -7,6 +7,7 @@ v0.3 (*unreleased*)
 - support `black`'s string normalization option (:pull:`59`)
 - add colors to the output (:pull:`60`)
 - make the order of the printed files predictable (:pull:`61`)
+- make sure blocks end with a empty continuation line (:pull:`62`)
 
 
 v0.2 (01 October 2020)


### PR DESCRIPTION
This adds empty continuation lines to the end of blocks (no splitting of incorrectly joined blocks, though).

 - [x] Closes #52
 - [x] Tests added
 - [x] Passes `isort . && black . && flake8`
 - [x] User visible changes (including notable bug fixes) are documented in `changelog.rst`
