### PR TITLE
Contributing guide

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -8,6 +8,7 @@ v0.3 (*unreleased*)
 - add colors to the output (:pull:`60`)
 - make the order of the printed files predictable (:pull:`61`)
 - make sure blocks end with a empty continuation line (:pull:`62`)
+- add a initial version of a contributing guide (:pull:`63`)
 
 
 v0.2 (01 October 2020)

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -26,3 +26,9 @@ correct using
    python -m blackdoc.tests.data format
 
 where ``format`` is a placeholder for the name of one of the supported formats.
+
+
+.. _black: https://black.readthedocs.io/en/stable/
+.. _flake8: https://flake8.pycqa.org/en/stable/
+.. _isort: https://pycqa.github.io/isort/
+.. _pre-commit: https://pre-commit.com/

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -1,0 +1,28 @@
+Contributing
+============
+
+``blackdoc`` uses several tools to ensure consistency (this is enforced using CI):
+
+- `black`_ for standardized code formatting
+- `flake8`_ for code quality
+- `isort`_ for standardized ordering of imports
+
+To avoid having to remember to manually run these tools before committing, using
+`pre-commit`_ is possible. After installing, enable it using
+
+.. code:: sh
+
+   python -m pip install pre-commit
+   # or
+   conda install -c conda-forge pre-commit
+
+   pre-commit install
+
+When modifying the test data in ``blackdoc/tests/data/format.py``, make sure the ranges are
+correct using
+
+.. code:: sh
+
+   python -m blackdoc.tests.data format
+
+where ``format`` is a placeholder for the name of one of the supported formats.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -10,12 +10,34 @@ The currently supported formats are:
 - ipython
 - rst
 
+Documentation
+-------------
+**User Guide**
+
+* :doc:`installing`
+* :doc:`usage`
+* :doc:`options`
+
 
 .. toctree::
    :maxdepth: 1
-   :caption: Contents
+   :caption: User Guide
+   :hidden:
 
    installing
    usage
    options
+
+**Help & Reference**
+
+* :doc:`changelog`
+* :doc:`contributing`
+
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Help & Reference
+   :hidden:
+
    changelog
+   contributing


### PR DESCRIPTION
This adds a contributing guide and mentions `python -m blackdoc.tests.data`, which helps with visually verifying the test data.

 - [x] Passes `isort . && black . && flake8`
 - [x] User visible changes (including notable bug fixes) are documented in `changelog.rst`