### PR TITLE
Update release guide

### DIFF
--- a/HOW_TO_RELEASE.rst
+++ b/HOW_TO_RELEASE.rst
@@ -63,12 +63,7 @@ Release process
       git push origin master
       git push origin --tags
 
-11. Draft a release on Github.  Be careful, this can't be undone.
-
-    A workflow will then publish to PyPI, which in turn will be picked up by conda-forge
-    and a PR will be opened automatically on the feedstock.
-              
-12. Update stable:
+11. Update stable:
 
     .. code:: sh
 
@@ -76,6 +71,11 @@ Release process
        git merge v0.X.Y
        git push origin stable
 
-13. Make sure readthedocs builds both `stable` and the new tag
+12. Make sure readthedocs builds both `stable` and the new tag
+
+13. Draft a release on Github.  Be careful, this can't be undone.
+
+    A workflow will then publish to PyPI, which in turn will be picked up by conda-forge
+    and a PR will be opened automatically on the feedstock.
 
 14. Add a new section to the changelog and push directly to master

--- a/HOW_TO_RELEASE.rst
+++ b/HOW_TO_RELEASE.rst
@@ -46,14 +46,15 @@ Release process
 
       python -m venv test
       source test/bin/activate
-      python -m pip install -r requirements.txt
+      python -m pip install -r dev-requirements.txt
       python -m pip install pytest
       python -m pip install dist/*.whl
       python -m pytest
       python -m blackdoc --check .; echo $?
       python -m blackdoc .; echo $?
       git reset --hard HEAD
-      rm -rf dist/
+      deactivate
+      git clean -xdf
 
 10. Push to master:
 


### PR DESCRIPTION
While releasing I found a few issues with the release guide. This shouldn't be user visible, so no changelog item.