### PR TITLE
Fix block detection

### DIFF
--- a/blackdoc/formats/doctest.py
+++ b/blackdoc/formats/doctest.py
@@ -10,7 +10,7 @@ prompt_re = re.compile(r"(>>> ?)")
 continuation_prompt = "..."
 continuation_prompt_re = re.compile(r"(\.\.\. ?)")
 include_pattern = r"\.pyi?$"
-block_start_re = re.compile(r"^[^:]+:(\s*#.*)?$")
+block_start_re = re.compile(r"^[^#:]+:(\s*#.*)?$")
 
 
 def continuation_lines(lines):

--- a/blackdoc/tests/data/doctest.py
+++ b/blackdoc/tests/data/doctest.py
@@ -29,6 +29,7 @@ docstring = """ a function to open files
     ...     print("caught")
     >>> a = 2
     ...
+    >>> # this is not a block:
 """
 lines = docstring.split("\n")
 labels = {
@@ -52,7 +53,8 @@ labels = {
     25: "none",
     (26, 28): "doctest",
     (28, 30): "doctest",
-    30: "none",
+    30: "doctest",
+    31: "none",
 }
 line_ranges, line_labels = from_dict(labels)
 
@@ -86,6 +88,7 @@ expected = """ a function to open files
     ...     print("caught")
     ...
     >>> a = 2
+    >>> # this is not a block:
 """
 expected_lines = expected.split("\n")
 expected_labels = {
@@ -109,6 +112,7 @@ expected_labels = {
     26: "none",
     (27, 30): "doctest",
     30: "doctest",
-    31: "none",
+    31: "doctest",
+    32: "none",
 }
 expected_line_ranges, expected_line_labels = from_dict(expected_labels)

--- a/blackdoc/tests/test_doctest.py
+++ b/blackdoc/tests/test_doctest.py
@@ -118,6 +118,11 @@ def prepare_lines(lines, remove_prompt=False):
             prepare_lines(expected_lines[29]),
             id="trailing newline at the end of a normal line",
         ),
+        pytest.param(
+            prepare_lines(lines[29], remove_prompt=True),
+            prepare_lines(expected_lines[30]),
+            id="trailing colon at the end of a comment",
+        ),
     ),
 )
 def test_reformatting_func(code_unit, expected):

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -3,7 +3,7 @@ Changelog
 
 v0.4 (*unreleased*)
 -------------------
-
+- don't detect comments ending with a colon as a block (:issue:`67`, :pull:`68`)
 
 v0.3 (04 November 2020)
 -----------------------


### PR DESCRIPTION
This modifies the block detection re to make sure something like
```python
>>> # this is not a block:
```
is not detected as a block.

 - [x] Closes #67
 - [x] Tests added
 - [x] Passes `isort . && black . && flake8`
 - [x] User visible changes (including notable bug fixes) are documented in `changelog.rst`