### PR TITLE
Colors to tty only

### DIFF
--- a/blackdoc/__main__.py
+++ b/blackdoc/__main__.py
@@ -160,13 +160,13 @@ def format_and_overwrite(path, mode):
         if new_content == content:
             result = "unchanged"
         else:
-            print(colorize(f"reformatted {path}", fg="white", bold=True))
+            err(f"reformatted {path}", fg="white", bold=True)
             result = "reformatted"
 
         with open(path, "w", encoding=encoding, newline=newline) as f:
             f.write(new_content)
     except black.InvalidInput as e:
-        print(colorize(f"error: cannot format {path.absolute()}: {e}", fg="red"))
+        err(f"error: cannot format {path.absolute()}: {e}", fg="red")
         result = "error"
 
     return result
@@ -184,14 +184,14 @@ def format_and_check(path, mode, diff=False, color=False):
         if new_content == content:
             result = "unchanged"
         else:
-            print(colorize(f"would reformat {path}", fg="white", bold=True))
+            err(f"would reformat {path}", fg="white", bold=True)
 
             if diff:
-                print(unified_diff(content, new_content, path, color))
+                out(unified_diff(content, new_content, path, color))
 
             result = "reformatted"
     except black.InvalidInput as e:
-        print(colorize(f"error: cannot format {path.absolute()}: {e}", fg="red"))
+        err(f"error: cannot format {path.absolute()}: {e}", fg="red")
         result = "error"
 
     return result
@@ -270,7 +270,7 @@ def statistics(sources):
 
 def process(args):
     if not args.src:
-        print(colorize("No Path provided. Nothing to do 😴", fg="white", bold=True))
+        err("No Path provided. Nothing to do 😴", fg="white", bold=True)
         return 0
 
     selected_formats = getattr(args, "formats", None)
@@ -286,25 +286,13 @@ def process(args):
     try:
         include_regex = black.re_compile_maybe_verbose(args.include)
     except black.re.error:
-        print(
-            colorize(
-                f"Invalid regular expression for include given: {args.include!r}",
-                fg="red",
-            ),
-            file=sys.stderr,
-        )
+        err(f"Invalid regular expression for include given: {args.include!r}", fg="red")
         return 2
 
     try:
         exclude_regex = black.re_compile_maybe_verbose(args.exclude)
     except black.re.error:
-        print(
-            colorize(
-                f"Invalid regular expression for exclude given: {args.exclude!r}",
-                fg="red",
-            ),
-            file=sys.stderr,
-        )
+        err(f"Invalid regular expression for exclude given: {args.exclude!r}", fg="red")
         return 2
 
     try:
@@ -313,12 +301,9 @@ def process(args):
             black.re_compile_maybe_verbose(force_exclude) if force_exclude else None
         )
     except black.re.error:
-        print(
-            colorize(
-                f"Invalid regular expression for force_exclude given: {force_exclude!r}",
-                fg="red",
-            ),
-            file=sys.stderr,
+        err(
+            f"Invalid regular expression for force_exclude given: {force_exclude!r}",
+            fg="red",
         )
         return 2
 
@@ -326,12 +311,10 @@ def process(args):
         collect_files(args.src, include_regex, exclude_regex, force_exclude_regex)
     )
     if len(sources) == 0:
-        print(
-            colorize(
-                "No files are present to be formatted. Nothing to do 😴",
-                fg="white",
-                bold=True,
-            )
+        err(
+            "No files are present to be formatted. Nothing to do 😴",
+            fg="white",
+            bold=True,
         )
         return 0
 
@@ -372,10 +355,14 @@ def process(args):
     else:
         return_code = 0
 
-    reformatted_message = colorize("Oh no! 💥 💔 💥", fg="white", bold=True)
-    no_reformatting_message = colorize("All done! ✨ 🍰 ✨", fg="white", bold=True)
-    print(reformatted_message if return_code else no_reformatting_message)
-    print(report)
+    reformatted_message = "Oh no! 💥 💔 💥"
+    no_reformatting_message = "All done! ✨ 🍰 ✨"
+    err(
+        reformatted_message if return_code else no_reformatting_message,
+        fg="white",
+        bold=True,
+    )
+    err(report)
     return return_code
 
 

--- a/blackdoc/__main__.py
+++ b/blackdoc/__main__.py
@@ -96,8 +96,8 @@ def remove_colors(message):
     return "".join(colors_re.split(message))
 
 
+# signature inspired by click.secho
 def custom_print(message, end="\n", file=sys.stdout, **styles):
-    # signature inspired by click.secho
     if file.isatty():
         message = colorize(message, **styles)
     else:

--- a/blackdoc/__main__.py
+++ b/blackdoc/__main__.py
@@ -2,7 +2,6 @@ import argparse
 import datetime
 import difflib
 import functools
-import os
 import pathlib
 import re
 import sys
@@ -99,7 +98,7 @@ def remove_colors(message):
 
 def custom_print(message, end="\n", file=sys.stdout, **styles):
     # signature inspired by click.secho
-    if os.isatty(file.fileno()):
+    if file.isatty():
         message = colorize(message, **styles)
     else:
         message = remove_colors(message)

--- a/blackdoc/blackcompat.py
+++ b/blackdoc/blackcompat.py
@@ -48,6 +48,23 @@ def find_project_root(srcs):
     return directory
 
 
+def wrap_stream_for_windows(f):
+    """
+    Wrap stream with colorama's wrap_stream so colors are shown on Windows.
+    If `colorama` is unavailable, the original stream is returned unmodified.
+    Otherwise, the `wrap_stream()` function determines whether the stream needs
+    to be wrapped for a Windows environment and will accordingly either return
+    an `AnsiToWin32` wrapper or the original stream.
+    """
+    try:
+        from colorama.initialise import wrap_stream
+    except ImportError:
+        return f
+    else:
+        # Set `strip=False` to avoid needing to modify test_express_diff_with_color.
+        return wrap_stream(f, convert=None, strip=False, autoreset=False, wrap=True)
+
+
 def find_pyproject_toml(path_search_start):
     """Find the absolute filepath to a pyproject.toml if it exists"""
     path_project_root = find_project_root(path_search_start)

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 v0.4 (*unreleased*)
 -------------------
 - don't detect comments ending with a colon as a block (:issue:`67`, :pull:`68`)
+- don't add color to redirected output and print reports to ``stderr`` (:issue:`66`, :pull:`69`)
 
 v0.3 (04 November 2020)
 -----------------------


### PR DESCRIPTION
This strips the color and font codes from the output if we're redirecting `stdout` and / or `stderr`. It also separates data output (diffs, they go to `stdout`) from the report (which goes to `stderr`), making the CLI behave closer to `black`.

 - [x] Closes #66
 - [ ] Tests added
 - [x] Passes `isort . && black . && flake8`
 - [x] User visible changes (including notable bug fixes) are documented in `changelog.rst`