### PR TITLE
fix the nightly CI run conditions

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -67,7 +67,6 @@ jobs:
     - name: Upload artifacts
       if: |
         ${{ steps.status.outcome }} == 'failure'
-        && github.event_name == 'schedule'
       uses: actions/upload-artifact@v2
       with:
         name: output-${{ matrix.python-version }}-log

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,8 +13,7 @@ jobs:
     name: upstream-dev
     runs-on: ubuntu-latest
     if: |
-      always()
-      && (github.repository == 'keewis/blackdoc' || github.event_name != 'schedule')
+      github.repository == 'keewis/blackdoc'
 
     strategy:
       fail-fast: false

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -67,7 +67,7 @@ jobs:
     - name: Upload artifacts
       if: |
         failure()
-        && ${{ steps.status.outcome }} == 'failure'
+        && steps.status.outcome == 'failure'
       uses: actions/upload-artifact@v2
       with:
         name: output-${{ matrix.python-version }}-log

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -66,7 +66,8 @@ jobs:
 
     - name: Upload artifacts
       if: |
-        ${{ steps.status.outcome }} == 'failure'
+        failure()
+        && ${{ steps.status.outcome }} == 'failure'
       uses: actions/upload-artifact@v2
       with:
         name: output-${{ matrix.python-version }}-log

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -66,7 +66,8 @@ jobs:
 
     - name: Upload artifacts
       if: |
-        ${{ steps.status.outputs.ARTIFACTS_AVAILABLE }} == 'true'
+        failure()
+        && ${{ steps.status.outputs.ARTIFACTS_AVAILABLE }} == 'true'
         && github.event_name == 'schedule'
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -68,6 +68,7 @@ jobs:
       if: |
         failure()
         && steps.status.outcome == 'failure'
+        && github.event_name == 'schedule'
       uses: actions/upload-artifact@v2
       with:
         name: output-${{ matrix.python-version }}-log

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -66,7 +66,7 @@ jobs:
 
     - name: Upload artifacts
       if: |
-        failure()
+        ${{ steps.status.outputs.ARTIFACTS_AVAILABLE }} == 'true'
         && github.event_name == 'schedule'
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -66,8 +66,7 @@ jobs:
 
     - name: Upload artifacts
       if: |
-        failure()
-        && ${{ steps.status.outputs.ARTIFACTS_AVAILABLE }} == 'true'
+        ${{ steps.status.outcome }} == 'failure'
         && github.event_name == 'schedule'
       uses: actions/upload-artifact@v2
       with:

--- a/blackdoc/tests/test_init.py
+++ b/blackdoc/tests/test_init.py
@@ -3,7 +3,3 @@ import blackdoc
 
 def test_version():
     assert getattr(blackdoc, "__version__", "") not in ("", "999")
-
-
-def test_failing():
-    assert False

--- a/blackdoc/tests/test_init.py
+++ b/blackdoc/tests/test_init.py
@@ -3,3 +3,7 @@ import blackdoc
 
 def test_version():
     assert getattr(blackdoc, "__version__", "") not in ("", "999")
+
+
+def test_failing():
+    assert False


### PR DESCRIPTION
Hopefully, this makes sure artifacts are only uploaded if the tests failed, and not if the import / dry run failed.