### PR TITLE
update the CI

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,3 +5,12 @@
  - [ ] Passes `isort . && black . && flake8`
  - [ ] User visible changes (including notable bug fixes) are documented in `changelog.rst`
  - [ ] New features are documented in the docs
+
+<!--
+By default, the upstream-dev is only run when triggered by the github website (`workflow_dispatch`)
+or if it was run on a schedule. To run it on a commit of a pull request (`pull_request`), include
+the `[test-upstream]` tag in the summary line of the commit message.
+
+For changes that are not covered by the CI please use the `[skip-ci]` tag to avoid running the
+normal CI.
+-->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   detect-skip-ci-trigger:
-    name: Detect CI Trigger
+    name: "Detect CI Trigger: [skip-ci]"
     runs-on: ubuntu-latest
     outputs:
       triggered: ${{ steps.detect-trigger.outputs.trigger-found }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,9 @@ jobs:
     steps:
     - name: checkout the repository
       uses: actions/checkout@v2
+      with:
+        # need to fetch all tags to get a correct version
+        fetch-depth: 0  # fetch all branches and tags
 
     - name: setup python
       uses: actions/setup-python@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,19 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
+    - name: Get pip cache dir
+      id: pip-cache
+      run: |
+        echo "::set-output name=dir::$(pip cache dir)"
+
+    - name: Cache pip
+      uses: actions/cache@v2
+      with:
+        path: ${{ steps.pip-cache.outputs.dir }}
+        key: ${{ runner.os }}-pip-py${{ matrix.python-version }}-${{ hashFiles('ci/requirements/**.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+
     - name: upgrade pip
       run: python -m pip install --upgrade pip
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,13 +9,30 @@ on:
     branches: [ master ]
 
 jobs:
-  linux:
-    name: Linux
+  detect-skip-ci-trigger:
+    name: Detect CI Trigger
     runs-on: ubuntu-latest
+    outputs:
+      triggered: ${{ steps.detect-trigger.outputs.trigger-found }}
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 2
+    - uses: keewis/ci-trigger@v1
+      id: detect-trigger
+      with:
+        keyword: "[skip-ci]"
+
+  unit-tests:
+    name: ${{ matrix.os }} py${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    needs: detect-skip-ci-trigger
+    if: needs.detect-skip-ci-trigger.outputs.triggered == 'false'
 
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8, 3.9]
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
     - name: checkout the repository
@@ -32,62 +49,6 @@ jobs:
     - name: install dependencies
       run: |
         python -m pip install -r ci/requirements/normal.txt
-
-    - name: install blackdoc
-      run: python -m pip install .
-
-    - name: show versions
-      run: python -m pip list
-
-    - name: run tests
-      run: python -m pytest
-
-  windows:
-    name: Windows (3.8)
-    runs-on: windows-latest
-
-    steps:
-    - name: checkout the repository
-      uses: actions/checkout@v2
-
-    - name: setup python
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
-
-    - name: upgrade pip
-      run: python -m pip install --upgrade pip
-
-    - name: install dependencies
-      run: python -m pip install -r ci/requirements/normal.txt
-
-    - name: install blackdoc
-      run: python -m pip install .
-
-    - name: show versions
-      run: python -m pip list
-
-    - name: run tests
-      run: python -m pytest
-
-  macos:
-    name: MacOS (3.8)
-    runs-on: macos-latest
-
-    steps:
-    - name: checkout the repository
-      uses: actions/checkout@v2
-
-    - name: setup python
-      uses: actions/setup-python@v2
-      with:
-        python-version: 3.8
-
-    - name: upgrade pip
-      run: python -m pip install --upgrade pip
-
-    - name: install dependencies
-      run: python -m pip install -r ci/requirements/normal.txt
 
     - name: install blackdoc
       run: python -m pip install .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Get pip cache dir
+    - name: get pip cache dir
       id: pip-cache
       run: |
         echo "::set-output name=dir::$(pip cache dir)"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -32,6 +32,9 @@ jobs:
 
     - name: checkout the repository
       uses: actions/checkout@v2
+      with:
+        # need to fetch all tags to get a correct version
+        fetch-depth: 0  # fetch all branches and tags
 
     - name: setup python
       uses: actions/setup-python@v2

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -7,6 +7,7 @@ on:
     branches: [ master ]
   schedule:
     - cron: "0 0 * * *"  # Daily "At 00:00" UTC
+  workflow_dispatch:
 
 jobs:
   upstream-dev:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -10,11 +10,33 @@ on:
   workflow_dispatch:
 
 jobs:
+  detect-test-upstream-trigger:
+    name: "Detect CI Trigger: [test-upstream]"
+    runs-on: ubuntu-latest
+    outputs:
+      triggered: ${{ steps.detect-trigger.outputs.trigger-found }}
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 2
+    - uses: keewis/ci-trigger@v1
+      id: detect-trigger
+      with:
+        keyword: "[test-upstream]"
+
   upstream-dev:
     name: upstream-dev
     runs-on: ubuntu-latest
+    needs: detect-test-upstream-trigger
+
     if: |
-      github.repository == 'keewis/blackdoc'
+      always()
+      && github.repository == 'keewis/blackdoc'
+      && (
+        github.event_name == 'schedule'
+        || github.event_name == 'workflow_dispatch'
+        || needs.detect-test-upstream-trigger.outputs.triggered == 'true'
+      )
 
     strategy:
       fail-fast: false

--- a/.github/workflows/parse_logs.py
+++ b/.github/workflows/parse_logs.py
@@ -30,14 +30,21 @@ def format_log_message(path):
     summary = f"Python {py_version} Test Summary Info"
     with open(path) as f:
         data = extract_short_test_summary_info(line.rstrip() for line in f)
-    message = textwrap.dedent(
-        f"""\
-        <details><summary>{summary}</summary>
-        ```
-        {data}
-        ```
-        </details>
-        """
+
+    message = (
+        textwrap.dedent(
+            """\
+            <details><summary>{summary}</summary>
+
+            ```
+            {data}
+            ```
+
+            </details>
+            """
+        )
+        .rstrip()
+        .format(summary=summary, data=data)
     )
 
     return message

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           twine check dist/*
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.4.1
+        uses: pypa/gh-action-pypi-publish@54b39fb9371c0b3a6f9f14bb8a67394defc7a806
         with:
           user: __token__
           password: ${{ secrets.pypi_token }}


### PR DESCRIPTION
This PR enables the use of trigger keywords (e.g. `[skip-ci]`) the summary line of the commit message, includes warnings in the body of issues opened by the scheduled CI and pins `pypa/gh-action-pypi-publish` to a SHA1 hash to make sure the PyPI token can't be leaked by a unpublish attack).

 - [x] Passes `isort . && black . && flake8`
