### PR TITLE
handle missing option separators

### DIFF
--- a/blackdoc/__init__.py
+++ b/blackdoc/__init__.py
@@ -5,7 +5,7 @@ except ImportError:
 
 from .blacken import blacken
 from .classification import detect_format
-from .formats import register_format  # noqa
+from .formats import InvalidFormatError, register_format  # noqa
 
 try:
     __version__ = version("blackdoc")

--- a/blackdoc/__main__.py
+++ b/blackdoc/__main__.py
@@ -164,7 +164,7 @@ def format_and_overwrite(path, mode):
 
         with open(path, "w", encoding=encoding, newline=newline) as f:
             f.write(new_content)
-    except black.InvalidInput as e:
+    except (black.InvalidInput, formats.InvalidFormatError) as e:
         err(f"error: cannot format {path.absolute()}: {e}", fg="red")
         result = "error"
 
@@ -189,7 +189,7 @@ def format_and_check(path, mode, diff=False, color=False):
                 out(unified_diff(content, new_content, path, color))
 
             result = "reformatted"
-    except black.InvalidInput as e:
+    except (black.InvalidInput, formats.InvalidFormatError) as e:
         err(f"error: cannot format {path.absolute()}: {e}", fg="red")
         result = "error"
 

--- a/blackdoc/formats/__init__.py
+++ b/blackdoc/formats/__init__.py
@@ -3,6 +3,7 @@ import textwrap
 import more_itertools
 
 from . import doctest, ipython, none, rst
+from .errors import InvalidFormatError  # noqa
 from .register import detection_funcs  # noqa
 from .register import disable  # noqa
 from .register import format_include_patterns  # noqa

--- a/blackdoc/formats/doctest.py
+++ b/blackdoc/formats/doctest.py
@@ -3,6 +3,8 @@ import re
 
 import more_itertools
 
+from .errors import InvalidFormatError
+
 name = "doctest"
 prompt_length = 4
 prompt = ">>>"
@@ -46,7 +48,7 @@ def detection_func(lines):
 
     line_range = min(line_numbers), max(line_numbers) + 1
     if line_numbers != tuple(range(line_range[0], line_range[1])):
-        raise RuntimeError("line numbers are not contiguous")
+        raise InvalidFormatError("line numbers are not contiguous")
 
     return line_range, name, "\n".join(lines)
 
@@ -85,7 +87,7 @@ def extraction_func(line):
         extract_prompt(line).rstrip() not in (prompt, continuation_prompt)
         for line in lines
     ):
-        raise RuntimeError(f"misformatted code unit: {line}")
+        raise InvalidFormatError(f"misformatted code unit: {line}")
 
     extracted_line = "\n".join(remove_prompt(line) for line in lines)
     docstring_quotes = detect_docstring_quotes(extracted_line)

--- a/blackdoc/formats/errors.py
+++ b/blackdoc/formats/errors.py
@@ -1,0 +1,2 @@
+class InvalidFormatError(ValueError):
+    pass

--- a/blackdoc/formats/ipython.py
+++ b/blackdoc/formats/ipython.py
@@ -3,6 +3,8 @@ import re
 
 import more_itertools
 
+from .errors import InvalidFormatError
+
 name = "ipython"
 
 prompt_re = re.compile(r"^(?P<indent>[ ]*)(?P<prompt>In \[(?P<count>\d+)\]: )")
@@ -59,7 +61,7 @@ def detection_func(lines):
 
     line_range = min(line_numbers), max(line_numbers) + 1
     if line_numbers != tuple(range(line_range[0], line_range[1])):
-        raise RuntimeError("line numbers are not contiguous")
+        raise InvalidFormatError("line numbers are not contiguous")
 
     return line_range, name, "\n".join(lines)
 
@@ -117,10 +119,13 @@ def extraction_func(code):
         return line[n:]
 
     lines = code.split("\n")
+    if len(lines) == 0:
+        raise InvalidFormatError("no lines found")
+
     parameters = metadata(lines[0])
 
     if not all(is_ipython(line) for line in lines):
-        raise RuntimeError(f"misformatted code unit: {code}")
+        raise InvalidFormatError(f"misformatted code unit: {code}")
 
     extracted = "\n".join(remove_prompt(line, **parameters) for line in lines)
 

--- a/blackdoc/formats/rst.py
+++ b/blackdoc/formats/rst.py
@@ -11,6 +11,7 @@ name = "rst"
 directive_re = re.compile(
     "(?P<indent>[ ]*).. (?P<name>[a-z][-a-z]*)::(?: (?P<language>[a-z]+))?"
 )
+option_re = re.compile(r"^\s*:[^:]+:")
 
 include_pattern = r"\.rst$"
 
@@ -30,7 +31,7 @@ def take_while(iterable, predicate):
 
 
 def continuation_lines(lines, indent):
-    options = tuple(take_while(lines, lambda x: x[1].strip()))
+    options = tuple(take_while(lines, lambda x: option_re.match(x[1])))
     newlines = tuple(take_while(lines, lambda x: not x[1].strip()))
     decorator_lines = tuple(take_while(lines, lambda x: x[1].lstrip().startswith("@")))
     _, next_line = lines.peek((0, None))

--- a/blackdoc/formats/rst.py
+++ b/blackdoc/formats/rst.py
@@ -128,16 +128,24 @@ def extraction_func(code):
     directive.pop("indent")
 
     directive["options"] = tuple(
-        line.strip() for line in take_while(lines, lambda line: line.strip())
+        line.strip() for line in take_while(lines, lambda line: option_re.match(line))
     )
 
-    line = more_itertools.first(lines)
-    if line.strip():
+    # correct a missing newline
+    newline = lines.peek(None)
+    if newline is None:
         raise RuntimeError(
-            f"misformatted code block: newline after options required but found: {line}"
+            "misformatted code block:"
+            " newline after directive options required"
+            " but found <end-of-file>"
         )
+    elif not newline.strip():
+        more_itertools.first(lines)
 
     lines_ = tuple(lines)
+    if len(lines_) == 0:
+        raise RuntimeError("misformatted code block: could not find any code")
+
     indent = len(lines_[0]) - len(lines_[0].lstrip())
     directive["prompt_length"] = indent
     directive["n_header_lines"] = len(directive["options"]) + 2

--- a/blackdoc/formats/rst.py
+++ b/blackdoc/formats/rst.py
@@ -4,6 +4,7 @@ import textwrap
 
 import more_itertools
 
+from .errors import InvalidFormatError
 from .ipython import hide_magic, prompt_re, reveal_magic
 
 name = "rst"
@@ -122,7 +123,7 @@ def extraction_func(code):
 
     match = directive_re.fullmatch(more_itertools.first(lines))
     if not match:
-        raise RuntimeError(f"misformatted code block:\n{code}")
+        raise InvalidFormatError(f"misformatted code block:\n{code}")
 
     directive = match.groupdict()
     directive.pop("indent")
@@ -134,7 +135,7 @@ def extraction_func(code):
     # correct a missing newline
     newline = lines.peek(None)
     if newline is None:
-        raise RuntimeError(
+        raise InvalidFormatError(
             "misformatted code block:"
             " newline after directive options required"
             " but found <end-of-file>"
@@ -144,7 +145,7 @@ def extraction_func(code):
 
     lines_ = tuple(lines)
     if len(lines_) == 0:
-        raise RuntimeError("misformatted code block: could not find any code")
+        raise InvalidFormatError("misformatted code block: could not find any code")
 
     indent = len(lines_[0]) - len(lines_[0].lstrip())
     directive["prompt_length"] = indent

--- a/blackdoc/tests/test_rst.py
+++ b/blackdoc/tests/test_rst.py
@@ -153,7 +153,7 @@ def test_detection_func(lines, expected):
                     "prompt_length": 4,
                     "n_header_lines": 2,
                 },
-                'print("abc")',
+                "\n".join(['print("abc")', ""]),
             ),
             id="missing sep line",
         ),

--- a/blackdoc/tests/test_rst.py
+++ b/blackdoc/tests/test_rst.py
@@ -119,6 +119,44 @@ def test_detection_func(lines, expected):
             ),
             id="ipython",
         ),
+        pytest.param(
+            textwrap.dedent(
+                """\
+                .. ipython:: python
+                    print("abc")
+                """
+            ).rstrip(),
+            (
+                {
+                    "name": "ipython",
+                    "language": "python",
+                    "options": (),
+                    "prompt_length": 4,
+                    "n_header_lines": 2,
+                },
+                'print("abc")',
+            ),
+            id="missing sep and eof line",
+        ),
+        pytest.param(
+            textwrap.dedent(
+                """\
+                .. ipython:: python
+                    print("abc")
+                """
+            ),
+            (
+                {
+                    "name": "ipython",
+                    "language": "python",
+                    "options": (),
+                    "prompt_length": 4,
+                    "n_header_lines": 2,
+                },
+                'print("abc")',
+            ),
+            id="missing sep line",
+        ),
     ),
 )
 def test_extraction_func(code, expected):

--- a/blackdoc/tests/test_rst.py
+++ b/blackdoc/tests/test_rst.py
@@ -46,6 +46,20 @@ from .data import rst as data
             ((1, 4), rst.name, "\n".join(data.lines[84:87])),
             id="testcleanup",
         ),
+        pytest.param(
+            [".. ipython:: python", '    print("abc")'],
+            (
+                (1, 3),
+                rst.name,
+                textwrap.dedent(
+                    """\
+                    .. ipython:: python
+                        print("abc")
+                    """
+                ).rstrip(),
+            ),
+            id="missing option separator",
+        ),
     ),
 )
 def test_detection_func(lines, expected):

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -3,7 +3,7 @@ Changelog
 
 v0.4 (*unreleased*)
 -------------------
-- don't crash on invalid rst directives (:issue:`78`, :pull:`79`)
+- don't crash on malformed rst directives (:issue:`78`, :pull:`79`)
 
 v0.3.2 (05 January 2021)
 ------------------------

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -3,7 +3,7 @@ Changelog
 
 v0.4 (*unreleased*)
 -------------------
-
+- don't crash on invalid rst directives (:issue:`78`, :pull:`79`)
 
 v0.3.2 (05 January 2021)
 ------------------------


### PR DESCRIPTION
Usually, a rst directive is followed by 0 or more options, a empty line and then the content. If the empty line is missing, the program currently crashes with a traceback.

 - [x] Closes #78
 - [x] Tests added
 - [x] Passes `isort . && black . && flake8`
 - [x] User visible changes (including notable bug fixes) are documented in `changelog.rst`
 - [ ] New features are documented in the docs

<!--
By default, the upstream-dev is only run when triggered by the github website (`workflow_dispatch`)
or if it was run on a schedule. To run it on a commit of a pull request (`pull_request`), include
the `[test-upstream]` tag in the summary line of the commit message.

For changes that are not covered by the CI please use the `[skip-ci]` tag to avoid running the
normal CI.
-->
