### PR TITLE
add a pre-commit autoupdate CI

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -1,0 +1,30 @@
+name: pre-commit autoupdate
+
+on:
+  schedule:
+    - cron: "0 0 * * 0"  # every Sunday at 00:00 UTC
+  workflow_dispatch:
+
+
+jobs:
+  autoupdate:
+    name: "pre-commit autoupdate"
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: setup python
+        uses: actions/setup-python@v2
+      - name: upgrade pip
+        run: python -m pip install --upgrade pip
+      - name: install pre-commit
+        run: python -m pip install --upgrade pre-commit
+      - name: autoupdate
+        uses: actions/create-pr-action@v2
+        with:
+          EXECUTE_COMMANDS: |
+            python -m pre_commit autoupdate
+          COMMIT_MESSAGE: "pre-commit: autoupdate hooks"
+          PR_TITLE: "pre-commit: autoupdate hooks"
+          PR_BRANCH_PREFIX: "pre-commit/"
+          PR_BRANCH_NAME: "autoupdate-${PR_ID}"

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -1,4 +1,4 @@
-name: pre-commit autoupdate
+name: "pre-commit autoupdate CI"
 
 on:
   schedule:


### PR DESCRIPTION
Right now we have to manually check whether there are new hook versions.

 - [x] Passes `isort . && black . && flake8`

<!--
By default, the upstream-dev is only run when triggered by the github website (`workflow_dispatch`)
or if it was run on a schedule. To run it on a commit of a pull request (`pull_request`), include
the `[test-upstream]` tag in the summary line of the commit message.

For changes that are not covered by the CI please use the `[skip-ci]` tag to avoid running the
normal CI.
-->
