### PR TITLE
update the vendored functions

### DIFF
--- a/blackdoc/blackcompat.py
+++ b/blackdoc/blackcompat.py
@@ -20,7 +20,7 @@ def find_project_root(srcs):
     project root, the root of the file system is returned.
     """
     if not srcs:
-        return Path("/").resolve()
+        return [str(Path.cwd().resolve())]
 
     path_srcs = [Path(Path.cwd(), src).resolve() for src in srcs]
 

--- a/blackdoc/blackcompat.py
+++ b/blackdoc/blackcompat.py
@@ -8,7 +8,7 @@ import sys
 from functools import lru_cache
 from pathlib import Path
 
-import toml
+import tomli
 
 
 @lru_cache()
@@ -105,9 +105,11 @@ def find_user_pyproject_toml() -> Path:
 def parse_pyproject_toml(path_config):
     """Parse a pyproject toml file, pulling out relevant parts for Black
 
-    If parsing fails, will raise a toml.TomlDecodeError
+    If parsing fails, will raise a tomli.TomlDecodeError
     """
-    pyproject_toml = toml.load(path_config)
+    with open(path_config, encoding="utf8") as f:
+        pyproject_toml = tomli.load(f)
+
     black_config = pyproject_toml.get("tool", {}).get("black", {})
     blackdoc_config = pyproject_toml.get("tool", {}).get("blackdoc", {})
     config = {**black_config, **blackdoc_config}
@@ -123,7 +125,7 @@ def read_pyproject_toml(source, config_path):
 
     try:
         config = parse_pyproject_toml(config_path)
-    except (toml.TomlDecodeError, OSError) as e:
+    except (tomli.TomlDecodeError, OSError) as e:
         raise IOError(f"Error reading configuration file ({config_path}): {e}")
 
     if not config:

--- a/blackdoc/blackcompat.py
+++ b/blackdoc/blackcompat.py
@@ -53,6 +53,7 @@ def find_project_root(srcs):
 def wrap_stream_for_windows(f):
     """
     Wrap stream with colorama's wrap_stream so colors are shown on Windows.
+
     If `colorama` is unavailable, the original stream is returned unmodified.
     Otherwise, the `wrap_stream()` function determines whether the stream needs
     to be wrapped for a Windows environment and will accordingly either return
@@ -88,7 +89,7 @@ def find_pyproject_toml(path_search_start):
 
 
 @lru_cache()
-def find_user_pyproject_toml() -> Path:
+def find_user_pyproject_toml():
     r"""Return the path to the top-level user configuration for black.
     This looks for ~\.black on Windows and ~/.config/black on Linux and other
     Unix systems.
@@ -136,6 +137,7 @@ def read_pyproject_toml(source, config_path):
 
 def normalize_path_maybe_ignore(path, root, report):
     """Normalize `path`. May return `None` if `path` was ignored.
+
     `report` is where "path ignored" output goes.
     """
     try:

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,8 @@ install_requires =
     black
     more_itertools
     importlib-metadata; python_version < "3.8"
-    toml
+    tomli
+    pathspec
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
The vendored functions have become out-of-date.

 - [x] Closes #100
 - [ ] Tests added
 - [x] Passes `isort . && black . && flake8`
 - [ ] User visible changes (including notable bug fixes) are documented in `changelog.rst`

<!--
By default, the upstream-dev is only run when triggered by the github website (`workflow_dispatch`)
or if it was run on a schedule. To run it on a commit of a pull request (`pull_request`), include
the `[test-upstream]` tag in the summary line of the commit message.

For changes that are not covered by the CI please use the `[skip-ci]` tag to avoid running the
normal CI.
-->
