### PR TITLE
update the vendored code

### DIFF
--- a/blackdoc/__main__.py
+++ b/blackdoc/__main__.py
@@ -12,6 +12,8 @@ from . import __version__, format_lines, formats
 from .blackcompat import (
     find_project_root,
     gen_python_files,
+    get_gitignore,
+    normalize_path_maybe_ignore,
     read_pyproject_toml,
     wrap_stream_for_windows,
 )
@@ -34,7 +36,7 @@ def check_format_names(string):
 
 def collect_files(src, include, exclude, extend_exclude, force_exclude, quiet, verbose):
     root, _ = find_project_root(tuple(src))
-    gitignore = black.get_gitignore(root)
+    gitignore = get_gitignore(root)
     report = black.Report()
 
     for path in src:
@@ -54,7 +56,7 @@ def collect_files(src, include, exclude, extend_exclude, force_exclude, quiet, v
         elif str(path) == "-":
             yield path
         elif path.is_file():
-            normalized_path = black.normalize_path_maybe_ignore(path, root, report)
+            normalized_path = normalize_path_maybe_ignore(path, root, report)
             if normalized_path is None:
                 continue
 

--- a/blackdoc/__main__.py
+++ b/blackdoc/__main__.py
@@ -341,7 +341,7 @@ def process(args):
         black.TargetVersion[version.upper()]
         for version in getattr(args, "target_versions", ())
     )
-    mode = black.FileMode(
+    mode = black.Mode(
         line_length=args.line_length,
         target_versions=target_versions,
         string_normalization=not args.skip_string_normalization,


### PR DESCRIPTION
`black` changed a lot since the last time I looked.

To stay as compatible as possible the vendored code should stay as close to the original as possible, but trying to only fall back to it if `black` removes the function does not make too much sense: we'd be importing private functions which can change at any moment. I'd be much more comfortable with that if the test suite was better, though.

 - [ ] Tests added
 - [x] Passes `isort . && black . && flake8`
 - [ ] User visible changes (including notable bug fixes) are documented in `changelog.rst`
 - [ ] New features are documented in the docs