### PR TITLE
split `__main__` into smaller modules

### DIFF
--- a/blackdoc/__main__.py
+++ b/blackdoc/__main__.py
@@ -1,6 +1,4 @@
 import argparse
-import datetime
-import difflib
 import pathlib
 import sys
 
@@ -14,7 +12,8 @@ from .blackcompat import (
     normalize_path_maybe_ignore,
     read_pyproject_toml,
 )
-from .colors import color_diff, colorize, err, out
+from .colors import colorize, err, out
+from .diff import unified_diff
 
 
 def check_format_names(string):
@@ -71,27 +70,6 @@ def collect_files(src, include, exclude, extend_exclude, force_exclude, quiet, v
             yield path
         else:
             print(f"invalid path: {path}", file=sys.stderr)
-
-
-def unified_diff(a, b, path, color):
-    then = datetime.datetime.utcfromtimestamp(path.stat().st_mtime)
-    now = datetime.datetime.utcnow()
-    src_name = f"{path}\t{then} +0000"
-    dst_name = f"{path}\t{now} +0000"
-
-    diff = "\n".join(
-        difflib.unified_diff(
-            a.splitlines(),
-            b.splitlines(),
-            fromfile=src_name,
-            tofile=dst_name,
-            lineterm="",
-        )
-    )
-    if color:
-        diff = color_diff(diff)
-
-    return diff
 
 
 def format_and_overwrite(path, mode):

--- a/blackdoc/__main__.py
+++ b/blackdoc/__main__.py
@@ -12,8 +12,9 @@ from .blackcompat import (
     normalize_path_maybe_ignore,
     read_pyproject_toml,
 )
-from .colors import colorize, err, out
+from .colors import err, out
 from .diff import unified_diff
+from .report import report_changes, report_possible_changes, statistics
 
 
 def check_format_names(string):
@@ -119,77 +120,6 @@ def format_and_check(path, mode, diff=False, color=False):
         result = "error"
 
     return result
-
-
-def report_changes(n_reformatted, n_unchanged, n_error):
-    def noun(n):
-        return "file" if n < 2 else "files"
-
-    reports = []
-    if n_reformatted > 0:
-        reports.append(
-            colorize(
-                f"{n_reformatted} {noun(n_reformatted)} reformatted",
-                fg="white",
-                bold=True,
-            )
-        )
-
-    if n_unchanged > 0:
-        reports.append(
-            colorize(f"{n_unchanged} {noun(n_unchanged)} left unchanged", fg="white")
-        )
-
-    if n_error > 0:
-        reports.append(
-            colorize(f"{n_error} {noun(n_error)} fails to reformat", fg="red")
-        )
-
-    return ", ".join(reports) + "."
-
-
-def report_possible_changes(n_reformatted, n_unchanged, n_error):
-    def noun(n):
-        return "file" if n < 2 else "files"
-
-    reports = []
-    if n_reformatted > 0:
-        reports.append(
-            colorize(
-                f"{n_reformatted} {noun(n_reformatted)} would be reformatted",
-                fg="white",
-                bold=True,
-            )
-        )
-
-    if n_unchanged > 0:
-        reports.append(
-            colorize(
-                f"{n_unchanged} {noun(n_unchanged)} would be left unchanged", fg="white"
-            )
-        )
-
-    if n_error > 0:
-        reports.append(
-            colorize(f"{n_error} {noun(n_error)} would fail to reformat", fg="red")
-        )
-
-    return ", ".join(reports) + "."
-
-
-def statistics(sources):
-    from collections import Counter
-
-    statistics = Counter(sources.values())
-
-    n_unchanged = statistics.pop("unchanged", 0)
-    n_reformatted = statistics.pop("reformatted", 0)
-    n_error = statistics.pop("error", 0)
-
-    if len(statistics) != 0:
-        raise RuntimeError(f"unknown results: {statistics.keys()}")
-
-    return n_reformatted, n_unchanged, n_error
 
 
 def process(args):

--- a/blackdoc/colors.py
+++ b/blackdoc/colors.py
@@ -1,0 +1,61 @@
+import functools
+import re
+import sys
+
+from .blackcompat import wrap_stream_for_windows
+
+colors_re = re.compile("\033" + r"\[[0-9]+(?:;[0-9]+)*m")
+
+
+def colorize(string, fg=None, bold=False):
+    foreground_colors = {
+        "white": 37,
+        "cyan": 36,
+        "green": 32,
+        "red": 31,
+    }
+    bold_code = 1
+    reset_code = 0
+
+    codes = []
+    if bold:
+        codes.append(bold_code)
+
+    if fg:
+        codes.append(foreground_colors.get(fg, fg))
+
+    return f"\033[{';'.join(map(str, codes))}m{string}\033[{reset_code}m"
+
+
+def remove_colors(message):
+    return "".join(colors_re.split(message))
+
+
+# signature inspired by click.secho
+def custom_print(message, end="\n", file=sys.stdout, **styles):
+    if file.isatty():
+        message = colorize(message, **styles)
+    else:
+        message = remove_colors(message)
+
+    print(message, end=end, file=wrap_stream_for_windows(file))
+
+
+out = functools.partial(custom_print, file=sys.stdout)
+err = functools.partial(custom_print, file=sys.stderr)
+
+
+def color_diff(contents):
+    """Inject the ANSI color codes to the diff."""
+    lines = contents.split("\n")
+    for i, line in enumerate(lines):
+        if line.startswith("+++") or line.startswith("---"):
+            line = colorize(line, fg="white", bold=True)  # bold white, reset
+        elif line.startswith("@@"):
+            line = colorize(line, fg="cyan")  # cyan, reset
+        elif line.startswith("+"):
+            line = colorize(line, fg="green")  # green, reset
+        elif line.startswith("-"):
+            line = colorize(line, fg="red")  # red, reset
+        lines[i] = line
+    return "\n".join(lines)

--- a/blackdoc/diff.py
+++ b/blackdoc/diff.py
@@ -1,0 +1,25 @@
+import datetime
+import difflib
+
+from .colors import color_diff
+
+
+def unified_diff(a, b, path, color):
+    then = datetime.datetime.utcfromtimestamp(path.stat().st_mtime)
+    now = datetime.datetime.utcnow()
+    src_name = f"{path}\t{then} +0000"
+    dst_name = f"{path}\t{now} +0000"
+
+    diff = "\n".join(
+        difflib.unified_diff(
+            a.splitlines(),
+            b.splitlines(),
+            fromfile=src_name,
+            tofile=dst_name,
+            lineterm="",
+        )
+    )
+    if color:
+        diff = color_diff(diff)
+
+    return diff

--- a/blackdoc/files.py
+++ b/blackdoc/files.py
@@ -1,0 +1,53 @@
+import sys
+
+from black import Report
+
+from .blackcompat import (
+    find_project_root,
+    gen_python_files,
+    get_gitignore,
+    normalize_path_maybe_ignore,
+)
+
+
+def collect_files(src, include, exclude, extend_exclude, force_exclude, quiet, verbose):
+    root, _ = find_project_root(tuple(src))
+    gitignore = get_gitignore(root)
+    report = Report()
+
+    for path in src:
+        if path.is_dir():
+            yield from gen_python_files(
+                path.iterdir(),
+                root,
+                include,
+                exclude,
+                extend_exclude,
+                force_exclude,
+                report,
+                gitignore,
+                quiet=quiet,
+                verbose=verbose,
+            )
+        elif str(path) == "-":
+            yield path
+        elif path.is_file():
+            normalized_path = normalize_path_maybe_ignore(path, root, report)
+            if normalized_path is None:
+                continue
+
+            normalized_path = "/" + normalized_path
+            # Hard-exclude any files that matches the `--force-exclude` regex.
+            if force_exclude:
+                force_exclude_match = force_exclude.search(normalized_path)
+            else:
+                force_exclude_match = None
+            if force_exclude_match and force_exclude_match.group(0):
+                report.path_ignored(
+                    path, "matches the --force-exclude regular expression"
+                )
+                continue
+
+            yield path
+        else:
+            print(f"invalid path: {path}", file=sys.stderr)

--- a/blackdoc/files.py
+++ b/blackdoc/files.py
@@ -1,5 +1,3 @@
-import sys
-
 from black import Report
 
 from .blackcompat import (
@@ -8,6 +6,7 @@ from .blackcompat import (
     get_gitignore,
     normalize_path_maybe_ignore,
 )
+from .colors import err
 
 
 def collect_files(src, include, exclude, extend_exclude, force_exclude, quiet, verbose):
@@ -50,4 +49,4 @@ def collect_files(src, include, exclude, extend_exclude, force_exclude, quiet, v
 
             yield path
         else:
-            print(f"invalid path: {path}", file=sys.stderr)
+            err(f"invalid path: {path}")

--- a/blackdoc/report.py
+++ b/blackdoc/report.py
@@ -1,0 +1,72 @@
+from .colors import colorize
+
+
+def report_changes(n_reformatted, n_unchanged, n_error):
+    def noun(n):
+        return "file" if n < 2 else "files"
+
+    reports = []
+    if n_reformatted > 0:
+        reports.append(
+            colorize(
+                f"{n_reformatted} {noun(n_reformatted)} reformatted",
+                fg="white",
+                bold=True,
+            )
+        )
+
+    if n_unchanged > 0:
+        reports.append(
+            colorize(f"{n_unchanged} {noun(n_unchanged)} left unchanged", fg="white")
+        )
+
+    if n_error > 0:
+        reports.append(
+            colorize(f"{n_error} {noun(n_error)} fails to reformat", fg="red")
+        )
+
+    return ", ".join(reports) + "."
+
+
+def report_possible_changes(n_reformatted, n_unchanged, n_error):
+    def noun(n):
+        return "file" if n < 2 else "files"
+
+    reports = []
+    if n_reformatted > 0:
+        reports.append(
+            colorize(
+                f"{n_reformatted} {noun(n_reformatted)} would be reformatted",
+                fg="white",
+                bold=True,
+            )
+        )
+
+    if n_unchanged > 0:
+        reports.append(
+            colorize(
+                f"{n_unchanged} {noun(n_unchanged)} would be left unchanged", fg="white"
+            )
+        )
+
+    if n_error > 0:
+        reports.append(
+            colorize(f"{n_error} {noun(n_error)} would fail to reformat", fg="red")
+        )
+
+    return ", ".join(reports) + "."
+
+
+def statistics(sources):
+    from collections import Counter
+
+    statistics = Counter(sources.values())
+
+    n_unchanged = statistics.pop("unchanged", 0)
+    n_reformatted = statistics.pop("reformatted", 0)
+    n_error = statistics.pop("error", 0)
+
+    if len(statistics) != 0:
+        raise RuntimeError(f"unknown results: {statistics.keys()}")
+
+    return n_reformatted, n_unchanged, n_error


### PR DESCRIPTION
The refactor is not quite done, but `__main__` should be much smaller.

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] towards #46
 - [x] Passes `pre-commit run --all-files`

<!--
By default, the upstream-dev is only run when triggered by the github website (`workflow_dispatch`)
or if it was run on a schedule. To run it on a commit of a pull request (`pull_request`), include
the `[test-upstream]` tag in the summary line of the commit message.

For changes that are not covered by the CI please use the `[skip-ci]` tag to avoid running the
normal CI.
-->