### PR TITLE
colorize trailing whitespace

### DIFF
--- a/blackdoc/colors.py
+++ b/blackdoc/colors.py
@@ -5,7 +5,7 @@ import sys
 from .blackcompat import wrap_stream_for_windows
 
 colors_re = re.compile("\033" + r"\[[0-9]+(?:;[0-9]+)*m")
-trailing_whitespace_re = re.compile(r"^.*(\s+)$")
+trailing_whitespace_re = re.compile(r"\s+$")
 
 
 def colorize(string, fg=None, bg=None, bold=False):
@@ -73,10 +73,10 @@ def color_diff(contents):
         elif line.startswith("+"):
             line = colorize(line, fg="green")
         elif line.startswith("-"):
+            match = trailing_whitespace_re.search(line)
             line = colorize(line.rstrip(), fg="red")
-            match = trailing_whitespace_re.match(line)
             if match:
-                whitespace = match.group(1)
+                whitespace = match.group(0)
                 line += colorize(whitespace, bg="red")
 
         return line

--- a/blackdoc/colors.py
+++ b/blackdoc/colors.py
@@ -5,6 +5,7 @@ import sys
 from .blackcompat import wrap_stream_for_windows
 
 colors_re = re.compile("\033" + r"\[[0-9]+(?:;[0-9]+)*m")
+trailing_whitespace_re = re.compile(r"^.*(\s+)$")
 
 
 def colorize(string, fg=None, bg=None, bold=False):
@@ -72,7 +73,11 @@ def color_diff(contents):
         elif line.startswith("+"):
             line = colorize(line, fg="green")
         elif line.startswith("-"):
-            line = colorize(line, fg="red")
+            line = colorize(line.rstrip(), fg="red")
+            match = trailing_whitespace_re.match(line)
+            if match:
+                whitespace = match.group(1)
+                line += colorize(whitespace, bg="red")
 
         return line
 

--- a/blackdoc/colors.py
+++ b/blackdoc/colors.py
@@ -9,10 +9,14 @@ colors_re = re.compile("\033" + r"\[[0-9]+(?:;[0-9]+)*m")
 
 def colorize(string, fg=None, bold=False):
     foreground_colors = {
-        "white": 37,
-        "cyan": 36,
-        "green": 32,
+        "black": 30,
         "red": 31,
+        "green": 32,
+        "yellow": 33,
+        "blue": 34,
+        "purple": 35,
+        "cyan": 36,
+        "white": 37,
     }
     bold_code = 1
     reset_code = 0

--- a/blackdoc/colors.py
+++ b/blackdoc/colors.py
@@ -63,8 +63,8 @@ err = functools.partial(custom_print, file=sys.stderr)
 
 def color_diff(contents):
     """Inject the ANSI color codes to the diff."""
-    lines = contents.split("\n")
-    for i, line in enumerate(lines):
+
+    def colorize_line(line):
         if line.startswith("+++") or line.startswith("---"):
             line = colorize(line, fg="white", bold=True)  # bold white, reset
         elif line.startswith("@@"):
@@ -73,5 +73,8 @@ def color_diff(contents):
             line = colorize(line, fg="green")  # green, reset
         elif line.startswith("-"):
             line = colorize(line, fg="red")  # red, reset
-        lines[i] = line
-    return "\n".join(lines)
+
+        return line
+
+    lines = contents.split("\n")
+    return "\n".join(colorize_line(line) for line in lines)

--- a/blackdoc/colors.py
+++ b/blackdoc/colors.py
@@ -66,13 +66,13 @@ def color_diff(contents):
 
     def colorize_line(line):
         if line.startswith("+++") or line.startswith("---"):
-            line = colorize(line, fg="white", bold=True)  # bold white, reset
+            line = colorize(line, fg="white", bold=True)
         elif line.startswith("@@"):
-            line = colorize(line, fg="cyan")  # cyan, reset
+            line = colorize(line, fg="cyan")
         elif line.startswith("+"):
-            line = colorize(line, fg="green")  # green, reset
+            line = colorize(line, fg="green")
         elif line.startswith("-"):
-            line = colorize(line, fg="red")  # red, reset
+            line = colorize(line, fg="red")
 
         return line
 

--- a/blackdoc/colors.py
+++ b/blackdoc/colors.py
@@ -4,6 +4,8 @@ import sys
 
 from .blackcompat import wrap_stream_for_windows
 
+# TODO: use rich instead
+
 colors_re = re.compile("\033" + r"\[[0-9]+(?:;[0-9]+)*m")
 trailing_whitespace_re = re.compile(r"\s+$")
 

--- a/blackdoc/colors.py
+++ b/blackdoc/colors.py
@@ -7,7 +7,7 @@ from .blackcompat import wrap_stream_for_windows
 colors_re = re.compile("\033" + r"\[[0-9]+(?:;[0-9]+)*m")
 
 
-def colorize(string, fg=None, bold=False):
+def colorize(string, fg=None, bg=None, bold=False):
     foreground_colors = {
         "black": 30,
         "red": 31,
@@ -18,6 +18,16 @@ def colorize(string, fg=None, bold=False):
         "cyan": 36,
         "white": 37,
     }
+    background_colors = {
+        "black": 40,
+        "red": 41,
+        "green": 42,
+        "yellow": 43,
+        "blue": 44,
+        "purple": 45,
+        "cyan": 46,
+        "white": 47,
+    }
     bold_code = 1
     reset_code = 0
 
@@ -27,6 +37,8 @@ def colorize(string, fg=None, bold=False):
 
     if fg:
         codes.append(foreground_colors.get(fg, fg))
+    if bg:
+        codes.append(background_colors.get(bg, bg))
 
     return f"\033[{';'.join(map(str, codes))}m{string}\033[{reset_code}m"
 

--- a/blackdoc/tests/test_colors.py
+++ b/blackdoc/tests/test_colors.py
@@ -1,0 +1,22 @@
+import re
+
+from blackdoc import colors
+
+
+def test_color_diff_trailing_whitespace():
+    # can't use triple-quotes because the formatters would remove the trailing whitespace
+    line = ">>> a"
+    whitespace = " " * 5
+    contents = "\n".join(
+        [
+            f"-{line}{whitespace}",
+            f"+{line}",
+        ]
+    )
+    colorized = colors.color_diff(contents)
+
+    pattern = colors.colors_re.pattern
+    expected_pattern = re.compile(rf"{pattern}\s+{pattern}")
+    match = expected_pattern.search(colorized)
+
+    assert match is not None and whitespace in match.group(0)

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 v0.4.0 (*unreleased*)
 ---------------------
 - officially support python 3.10 (:pull:`115`)
+- colorize removed trailing whitespace (:pull:`120`)
 
 v0.3.4 (17 July 2021)
 ---------------------


### PR DESCRIPTION
When trailing whitespace is removed, `blackdoc` would output two equal
lines, one prefixed with `-`, one with `+`. Since this is confusing,
it is better to colorize the removed whitespace.

(This won't happen at all if `blackdoc` is run after other formatters
that take care of trailing whitespace)

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Tests added
 - [x] Passes `pre-commit run --all-files`
 - [x] User visible changes (including notable bug fixes) are documented in `changelog.rst`

<!--
By default, the upstream-dev is only run when triggered by the github website (`workflow_dispatch`)
or if it was run on a schedule. To run it on a commit of a pull request (`pull_request`), include
the `[test-upstream]` tag in the summary line of the commit message.

For changes that are not covered by the CI please use the `[skip-ci]` tag to avoid running the
normal CI.
-->