### PR TITLE
write only if the file was reformatted

### DIFF
--- a/blackdoc/__main__.py
+++ b/blackdoc/__main__.py
@@ -40,8 +40,8 @@ def format_and_overwrite(path, mode):
             err(f"reformatted {path}", fg="white", bold=True)
             result = "reformatted"
 
-        with open(path, "w", encoding=encoding, newline=newline) as f:
-            f.write(new_content)
+            with open(path, "w", encoding=encoding, newline=newline) as f:
+                f.write(new_content)
     except (black.InvalidInput, formats.InvalidFormatError) as e:
         err(f"error: cannot format {path.absolute()}: {e}", fg="red")
         result = "error"

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -5,6 +5,7 @@ v0.4.0 (*unreleased*)
 ---------------------
 - officially support python 3.10 (:pull:`115`)
 - colorize removed trailing whitespace (:pull:`120`)
+- write only if the content of a file changed (:issue:`127`, :pull:`128`)
 
 v0.3.4 (17 July 2021)
 ---------------------


### PR DESCRIPTION
cc @max-sixty

 - [x] Closes #127
 - [ ] Tests added
 - [x] Passes `pre-commit run --all-files`
 - [x] User visible changes (including notable bug fixes) are documented in `changelog.rst`

Tests will have to wait until I figure out a good way to test the cli.