### PR TITLE
properly detect triple quotes

### DIFF
--- a/blackdoc/tests/test_doctest.py
+++ b/blackdoc/tests/test_doctest.py
@@ -128,11 +128,11 @@ def prepare_lines(lines, remove_prompt=False):
     ),
 )
 def test_reformatting_func(code_unit, expected):
-    docstring_quotes = doctest.detect_docstring_quotes(code_unit)
+    expected_quotes = doctest.detect_docstring_quotes(expected)
 
-    actual = doctest.reformatting_func(code_unit, docstring_quotes)
+    actual = doctest.reformatting_func(code_unit, expected_quotes)
     assert expected == actual
 
     # make sure the docstring quotes were not changed
     actual_quotes = doctest.detect_docstring_quotes(actual)
-    assert docstring_quotes == actual_quotes
+    assert expected_quotes == actual_quotes

--- a/blackdoc/tests/test_doctest.py
+++ b/blackdoc/tests/test_doctest.py
@@ -11,9 +11,11 @@ from .data.doctest import expected_lines, lines
 @pytest.mark.parametrize(
     ("string", "expected"),
     (
-        pytest.param("a", None, id="no quotes"),
-        pytest.param("'''a'''", "'''", id="single quotes"),
-        pytest.param('"""a"""', '"""', id="double quotes"),
+        pytest.param("", [None], id="empty string"),
+        pytest.param("a", [None], id="no quotes"),
+        pytest.param("'''a'''", ["'''"], id="single quotes"),
+        pytest.param('"""a"""', ['"""'], id="double quotes"),
+        pytest.param('"a"""', [None], id="trailing empty string"),
     ),
 )
 def test_detect_docstring_quotes(string, expected):
@@ -132,4 +134,5 @@ def test_reformatting_func(code_unit, expected):
     assert expected == actual
 
     # make sure the docstring quotes were not changed
-    assert docstring_quotes is None or docstring_quotes in actual
+    actual_quotes = doctest.detect_docstring_quotes(actual)
+    assert docstring_quotes == actual_quotes

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -6,6 +6,7 @@ v0.4.0 (*unreleased*)
 - officially support python 3.10 (:pull:`115`)
 - colorize removed trailing whitespace (:pull:`120`)
 - write only if the content of a file changed (:issue:`127`, :pull:`128`)
+- don't crash on strings with trailing empty strings (`"a"""`) (:issue:`131`, :pull:`132`)
 
 v0.3.4 (17 July 2021)
 ---------------------


### PR DESCRIPTION
It doesn't seem to be possible to detect the difference between `"string"""` and `"""string"""` with just string matching (or at least complicated), so this uses the `tokenize` module instead. In the future we might want to switch to `ast` instead, which would also allow fixing #15.

<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] Closes #131
 - [x] Tests added
 - [x] Passes `pre-commit run --all-files`
 - [x] User visible changes (including notable bug fixes) are documented in `changelog.rst`

<!--
By default, the upstream-dev is only run when triggered by the github website (`workflow_dispatch`)
or if it was run on a schedule. To run it on a commit of a pull request (`pull_request`), include
the `[test-upstream]` tag in the summary line of the commit message.

For changes that are not covered by the CI please use the `[skip-ci]` tag to avoid running the
normal CI.
-->