### PR TITLE
Fix doctest truncation upon reformatting

### DIFF
--- a/blackdoc/formats/doctest.py
+++ b/blackdoc/formats/doctest.py
@@ -156,6 +156,7 @@ def reformatting_func(line, docstring_quotes):
         for line, saved, current in itertools.zip_longest(
             reformatted, docstring_quotes, current_quotes
         )
+        if line is not None
     )
 
     return restored

--- a/blackdoc/formats/doctest.py
+++ b/blackdoc/formats/doctest.py
@@ -153,7 +153,9 @@ def reformatting_func(line, docstring_quotes):
     current_quotes = detect_docstring_quotes("\n".join(reformatted))
     restored = "\n".join(
         line.replace(current, saved) if current != saved else line
-        for line, saved, current in zip(reformatted, docstring_quotes, current_quotes)
+        for line, saved, current in itertools.zip_longest(
+            reformatted, docstring_quotes, current_quotes
+        )
     )
 
     return restored

--- a/blackdoc/formats/doctest.py
+++ b/blackdoc/formats/doctest.py
@@ -127,6 +127,15 @@ def extraction_func(line):
     }, extracted_line
 
 
+def replace_quotes(line, current, saved):
+    if current is None or saved is None:
+        return line
+    elif current == saved:
+        return line
+    else:
+        return line.replace(current, saved)
+
+
 def reformatting_func(line, docstring_quotes):
     def add_prompt(prompt, line):
         if not line:
@@ -152,7 +161,7 @@ def reformatting_func(line, docstring_quotes):
     # make sure nested docstrings still work
     current_quotes = detect_docstring_quotes("\n".join(reformatted))
     restored = "\n".join(
-        line.replace(current, saved) if current != saved else line
+        replace_quotes(line, current, saved)
         for line, saved, current in itertools.zip_longest(
             reformatted, docstring_quotes, current_quotes
         )

--- a/blackdoc/tests/test_doctest.py
+++ b/blackdoc/tests/test_doctest.py
@@ -154,7 +154,6 @@ def prepare_lines(lines, remove_prompt=False):
                 """.rstrip()
             ),
             id="multiple lines with less quotes",
-            marks=[pytest.mark.skip(reason="to be fixed")],
         ),
         pytest.param(
             textwrap.dedent(
@@ -175,7 +174,6 @@ def prepare_lines(lines, remove_prompt=False):
                 """.rstrip()
             ),
             id="multiple lines with more quotes",
-            marks=[pytest.mark.skip(reason="to be fixed")],
         ),
         pytest.param(
             textwrap.dedent(
@@ -212,7 +210,6 @@ def prepare_lines(lines, remove_prompt=False):
                 """.rstrip()
             ),
             id="multi-line triple-quoted string with less quotes",
-            marks=[pytest.mark.skip(reason="to be fixed")],
         ),
         pytest.param(
             textwrap.dedent(
@@ -231,7 +228,6 @@ def prepare_lines(lines, remove_prompt=False):
                 """.rstrip()
             ),
             id="multi-line triple-quoted string with more quotes",
-            marks=[pytest.mark.skip(reason="to be fixed")],
         ),
         pytest.param(
             textwrap.dedent(
@@ -314,6 +310,7 @@ def prepare_lines(lines, remove_prompt=False):
                 ...
                 """.rstrip()
             ),
+            id="nested docstring",
         ),
     ),
 )

--- a/blackdoc/tests/test_doctest.py
+++ b/blackdoc/tests/test_doctest.py
@@ -312,6 +312,13 @@ def prepare_lines(lines, remove_prompt=False):
             ),
             id="nested docstring",
         ),
+        pytest.param(
+            "s = '''triple-quoted string'''",
+            [None, "'''", None],
+            ">>> s = '''triple-quoted string'''",
+            id="moved triple-quoted string",
+            marks=[pytest.mark.skip(reason="to be fixed")],
+        ),
     ),
 )
 def test_reformatting_func(code_unit, docstring_quotes, expected):

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -3,7 +3,8 @@ Changelog
 
 v0.4.0 (*unreleased*)
 ---------------------
-
+- fix a regression in the doctest format that would either truncate
+  the reformatted code or crash it (:pull:`137`)
 
 v0.3.5 (26 July 2022)
 ---------------------


### PR DESCRIPTION
This PR addresses a bug that where doctests that would be reformatted to span more lines than they occupied originally would be truncated to the original number of lines.

Example:
`python -m blackdoc doc/directory/file.py` resulted in the following:
```python
doctests:
>>> s = {
...     "a",
...     "b",
```

Changing `zip` to `zip_longest` in `doctest.reformatting_func` appears to fix the bug, resulting in the correct output:
```python
doctests:
>>> s = {
...     "a",
...     "b",
...     "c",
...     "d",
...     "e",
...     "f",
...     "e",
...     "f",
...     "g",
...     "h",
...     "i",
...     "j",
...     "k",
...     "l",
...     "m",
... }
```