### PR TITLE
add a minimum version for sphinx

### DIFF
--- a/ci/requirements/doc.txt
+++ b/ci/requirements/doc.txt
@@ -1,4 +1,4 @@
-sphinx
+sphinx>=5
 sphinx_rtd_theme
 ipython
 more-itertools

--- a/ci/requirements/doc.txt
+++ b/ci/requirements/doc.txt
@@ -1,4 +1,4 @@
 sphinx>=5
-sphinx_rtd_theme
+sphinx_rtd_theme>=1.0
 ipython
 more-itertools


### PR DESCRIPTION
Because otherwise the RTD defaults would take precedence, which are way too old.