### PR TITLE
replace triple-quotes by modifying tokens

### DIFF
--- a/blackdoc/formats/doctest.py
+++ b/blackdoc/formats/doctest.py
@@ -84,11 +84,6 @@ def extract_string_tokens(code):
     )
 
 
-def expand_tokens(token):
-    length = token.end[0] - token.start[0] + 1
-    return [token.string] * length
-
-
 def detect_docstring_quotes(line):
     def detect_quotes(string):
         if string.startswith("'''"):

--- a/blackdoc/formats/doctest.py
+++ b/blackdoc/formats/doctest.py
@@ -94,17 +94,11 @@ def detect_docstring_quotes(line):
         else:
             return None
 
-    def expand_quotes(quotes, n_lines):
-        lines = [None] * n_lines
-        for token, quote in quotes.items():
-            token_length = token.end[0] - token.start[0] + 1
-            lines[token.start[0] - 1 : token.end[0]] = [quote] * token_length
-        return lines
+    string_tokens = list(extract_string_tokens(line))
+    token_quotes = {token: detect_quotes(token.string) for token in string_tokens}
+    quotes = set(token_quotes.values())
 
-    string_tokens = list(tokenize(line))
-    quotes = {token: detect_quotes(token.string) for token in string_tokens}
-    lines = line.split("\n")
-    return expand_quotes(quotes, len(lines))
+    return more_itertools.first(quotes, None)
 
 
 def extraction_func(line):

--- a/blackdoc/formats/doctest.py
+++ b/blackdoc/formats/doctest.py
@@ -168,9 +168,6 @@ def restore_quotes(code_unit, original_quotes):
     offsets = line_offsets(code_unit)
     mutable_string = io.StringIO(code_unit)
     for token in triple_quote_tokens:
-        # reset stream
-        mutable_string.seek(0)
-
         # find the offset in the stream
         start = compute_offset(token.start, offsets)
         end = compute_offset(token.end, offsets) - 3
@@ -181,7 +178,6 @@ def restore_quotes(code_unit, original_quotes):
         mutable_string.seek(end)
         mutable_string.write(original_quotes)
 
-    mutable_string.seek(0)
     restored_code_unit = mutable_string.getvalue()
 
     return restored_code_unit

--- a/blackdoc/formats/doctest.py
+++ b/blackdoc/formats/doctest.py
@@ -1,3 +1,4 @@
+import io
 import itertools
 import re
 import tokenize
@@ -66,12 +67,15 @@ def suppress(iterable, errors):
             break
 
 
-def extract_string_tokens(code):
-    import io
-
+def tokenize_string(code):
     readline = io.StringIO(code).readline
 
-    tokens = tokenize.generate_tokens(readline)
+    return tokenize.generate_tokens(readline)
+
+
+def extract_string_tokens(code):
+    tokens = tokenize_string(code)
+
     # suppress invalid code errors: `black` will raise with a better error message
     return (
         token

--- a/blackdoc/formats/doctest.py
+++ b/blackdoc/formats/doctest.py
@@ -140,6 +140,15 @@ def restore_quotes(code_unit, original_quotes):
             string.startswith('"""') and string.endswith('"""')
         )
 
+    def line_offsets(code_unit):
+        offsets = {
+            lineno: m.start()
+            for lineno, m in enumerate(re.finditer("\n", code_unit), start=2)
+        }
+        offsets[1] = 0
+
+        return offsets
+
     def compute_offset(pos, offsets):
         lineno, charno = pos
         return offsets[lineno] + charno + 1
@@ -156,11 +165,7 @@ def restore_quotes(code_unit, original_quotes):
         if token.string.startswith(to_replace) and token.string.endswith(to_replace)
     ]
 
-    offsets = {1: 0} | {
-        lineno: m.start()
-        for lineno, m in enumerate(re.finditer("\n", code_unit), start=2)
-    }
-
+    offsets = line_offsets(code_unit)
     mutable_string = io.StringIO(code_unit)
     for token in triple_quote_tokens:
         # reset stream

--- a/blackdoc/formats/doctest.py
+++ b/blackdoc/formats/doctest.py
@@ -84,18 +84,18 @@ def extract_string_tokens(code):
     )
 
 
-def detect_docstring_quotes(line):
-    def detect_quotes(string):
-        if string.startswith("'''"):
+def detect_docstring_quotes(code_unit):
+    def extract_quotes(string):
+        if string.startswith("'''") and string.endswith("'''"):
             return "'''"
-        elif string.startswith('"""'):
+        elif string.startswith('"""') and string.endswith('"""'):
             return '"""'
         else:
             return None
 
-    string_tokens = list(extract_string_tokens(line))
-    token_quotes = {token: detect_quotes(token.string) for token in string_tokens}
-    quotes = set(token_quotes.values())
+    string_tokens = list(extract_string_tokens(code_unit))
+    token_quotes = {token: extract_quotes(token.string) for token in string_tokens}
+    quotes = (quote for quote in token_quotes.values() if quote is not None)
 
     return more_itertools.first(quotes, None)
 

--- a/blackdoc/formats/doctest.py
+++ b/blackdoc/formats/doctest.py
@@ -1,5 +1,7 @@
 import itertools
 import re
+import tokenize
+from tokenize import TokenError
 
 import more_itertools
 
@@ -53,16 +55,28 @@ def detection_func(lines):
     return line_range, name, "\n".join(lines)
 
 
-def tokenize(code):
+def suppress(iterable, errors):
+    iter_ = iter(iterable)
+    while True:
+        try:
+            yield next(iter_)
+        except errors:
+            yield None
+        except StopIteration:
+            break
+
+
+def extract_string_tokens(code):
     import io
-    import tokenize
 
     readline = io.StringIO(code).readline
 
+    tokens = tokenize.generate_tokens(readline)
+    # suppress invalid code errors: `black` will raise with a better error message
     return (
         token
-        for token in tokenize.generate_tokens(readline)
-        if token.type == tokenize.STRING
+        for token in suppress(tokens, TokenError)
+        if token is not None and token.type == tokenize.STRING
     )
 
 

--- a/blackdoc/formats/doctest.py
+++ b/blackdoc/formats/doctest.py
@@ -135,11 +135,6 @@ def extraction_func(line):
 
 
 def restore_quotes(code_unit, original_quotes):
-    def is_docstring(string):
-        return (string.startswith("'''") and string.endswith("'''")) or (
-            string.startswith('"""') and string.endswith('"""')
-        )
-
     def line_offsets(code_unit):
         offsets = [m.end() for m in re.finditer("\n", code_unit)]
 

--- a/blackdoc/formats/doctest.py
+++ b/blackdoc/formats/doctest.py
@@ -142,7 +142,7 @@ def restore_quotes(code_unit, original_quotes):
 
     def compute_offset(pos, offsets):
         lineno, charno = pos
-        return offsets[lineno - 1] + charno + 1
+        return offsets[lineno] + charno + 1
 
     if original_quotes is None:
         return code_unit
@@ -156,8 +156,10 @@ def restore_quotes(code_unit, original_quotes):
         if token.string.startswith(to_replace) and token.string.endswith(to_replace)
     ]
 
-    line_lengths = [len(line) for line in code_unit.split("\n")]
-    offsets = [0] + list(itertools.accumulate(line_lengths[:-1]))
+    offsets = {1: 0} | {
+        lineno: m.start()
+        for lineno, m in enumerate(re.finditer("\n", code_unit), start=2)
+    }
 
     mutable_string = io.StringIO(code_unit)
     for token in triple_quote_tokens:

--- a/blackdoc/formats/doctest.py
+++ b/blackdoc/formats/doctest.py
@@ -141,17 +141,13 @@ def restore_quotes(code_unit, original_quotes):
         )
 
     def line_offsets(code_unit):
-        offsets = {
-            lineno: m.start()
-            for lineno, m in enumerate(re.finditer("\n", code_unit), start=2)
-        }
-        offsets[1] = 0
+        offsets = [m.end() for m in re.finditer("\n", code_unit)]
 
-        return offsets
+        return {lineno: offset for lineno, offset in enumerate([0] + offsets, start=1)}
 
     def compute_offset(pos, offsets):
         lineno, charno = pos
-        return offsets[lineno] + charno + 1
+        return offsets[lineno] + charno
 
     if original_quotes is None:
         return code_unit

--- a/blackdoc/tests/test_doctest.py
+++ b/blackdoc/tests/test_doctest.py
@@ -248,8 +248,8 @@ def prepare_lines(lines, remove_prompt=False):
         ),
         pytest.param(
             "s = '''triple-quoted string'''",
-            "'''",
-            ">>> s = '''triple-quoted string'''",
+            '"""',
+            '>>> s = """triple-quoted string"""',
             id="triple-quoted string",
         ),
         pytest.param(
@@ -260,13 +260,13 @@ def prepare_lines(lines, remove_prompt=False):
                 '''
                 """
             ).rstrip(),
-            "'''",
+            '"""',
             textwrap.dedent(
-                """\
-                >>> s = '''
+                '''\
+                >>> s = """
                 ...     triple-quoted string
-                ... '''
-                """.rstrip(),
+                ... """
+                '''.rstrip(),
             ),
             id="multi-line triple-quoted string",
         ),

--- a/blackdoc/tests/test_doctest.py
+++ b/blackdoc/tests/test_doctest.py
@@ -11,11 +11,11 @@ from .data.doctest import lines
 @pytest.mark.parametrize(
     ("string", "expected"),
     (
-        pytest.param("", [None], id="empty string"),
-        pytest.param("a", [None], id="no quotes"),
-        pytest.param("'''a'''", ["'''"], id="single quotes"),
-        pytest.param('"""a"""', ['"""'], id="double quotes"),
-        pytest.param('"a"""', [None], id="trailing empty string"),
+        pytest.param("", None, id="empty string"),
+        pytest.param("a", None, id="no quotes"),
+        pytest.param("'''a'''", "'''", id="single quotes"),
+        pytest.param('"""a"""', '"""', id="double quotes"),
+        pytest.param('"a"""', None, id="trailing empty string"),
     ),
 )
 def test_detect_docstring_quotes(string, expected):

--- a/blackdoc/tests/test_doctest.py
+++ b/blackdoc/tests/test_doctest.py
@@ -271,6 +271,25 @@ def prepare_lines(lines, remove_prompt=False):
             ),
             id="docstring and trailing empty string",
         ),
+        pytest.param(
+            textwrap.dedent(
+                '''\
+                def f(arg1, arg2):
+                    """ docstring """
+                    s = """triple-quoted string"""
+                '''
+            ),
+            "'''",
+            textwrap.dedent(
+                """\
+                >>> def f(arg1, arg2):
+                ...     ''' docstring '''
+                ...     s = '''triple-quoted string'''
+                ...
+                """.rstrip()
+            ),
+            id="docstring and triple-quoted string",
+        ),
     ),
 )
 def test_reformatting_func(code_unit, docstring_quotes, expected):

--- a/blackdoc/tests/test_doctest.py
+++ b/blackdoc/tests/test_doctest.py
@@ -109,33 +109,21 @@ def prepare_lines(lines, remove_prompt=False):
     (
         pytest.param(
             "file",
-            [None],
+            None,
             ">>> file",
             id="single line",
         ),
         pytest.param(
             "",
-            [None],
+            None,
             ">>>",
             id="single empty line",
         ),
         pytest.param(
-            "file",
-            [None, None, None],
-            ">>> file",
-            id="single line with more quotes",
-        ),
-        pytest.param(
             '"""docstring"""',
-            ['"""'],
+            '"""',
             '>>> """docstring"""',
             id="single-line triple-quoted string",
-        ),
-        pytest.param(
-            '"""docstring"""',
-            ['"""', '"""'],
-            '>>> """docstring"""',
-            id="single-line triple-quoted string with more quotes",
         ),
         pytest.param(
             textwrap.dedent(
@@ -146,7 +134,7 @@ def prepare_lines(lines, remove_prompt=False):
                 ]
                 """.rstrip()
             ),
-            [None, None, None, None],
+            None,
             textwrap.dedent(
                 """\
                 >>> a = [
@@ -160,52 +148,12 @@ def prepare_lines(lines, remove_prompt=False):
         pytest.param(
             textwrap.dedent(
                 """\
-                a = [
-                    1,
-                    2,
-                ]
-                """.rstrip()
-            ),
-            [None, None],
-            textwrap.dedent(
-                """\
-                >>> a = [
-                ...     1,
-                ...     2,
-                ... ]
-                """.rstrip()
-            ),
-            id="multiple lines with less quotes",
-        ),
-        pytest.param(
-            textwrap.dedent(
-                """\
-                a = [
-                    1,
-                    2,
-                ]
-                """.rstrip()
-            ),
-            [None, None, None, None, None],
-            textwrap.dedent(
-                """\
-                >>> a = [
-                ...     1,
-                ...     2,
-                ... ]
-                """.rstrip()
-            ),
-            id="multiple lines with more quotes",
-        ),
-        pytest.param(
-            textwrap.dedent(
-                """\
                 '''
                 docstring content
                 '''
                 """.rstrip()
             ),
-            ["'''", "'''", "'''"],
+            "'''",
             textwrap.dedent(
                 """\
                 >>> '''
@@ -218,49 +166,13 @@ def prepare_lines(lines, remove_prompt=False):
         pytest.param(
             textwrap.dedent(
                 """\
-                '''
-                docstring content
-                '''
-                """.rstrip()
-            ),
-            ["'''"],
-            textwrap.dedent(
-                """\
-                >>> '''
-                ... docstring content
-                ... '''
-                """.rstrip()
-            ),
-            id="multi-line triple-quoted string with less quotes",
-        ),
-        pytest.param(
-            textwrap.dedent(
-                """\
-                '''
-                docstring content
-                '''
-                """.rstrip()
-            ),
-            ["'''", "'''", "'''", None, None],
-            textwrap.dedent(
-                """\
-                >>> '''
-                ... docstring content
-                ... '''
-                """.rstrip()
-            ),
-            id="multi-line triple-quoted string with more quotes",
-        ),
-        pytest.param(
-            textwrap.dedent(
-                """\
                 ''' arbitrary triple-quoted string
 
                 with a empty continuation line
                 '''
                 """.rstrip(),
             ),
-            ["'''", "'''", "'''", "'''"],
+            "'''",
             textwrap.dedent(
                 """\
                 >>> ''' arbitrary triple-quoted string
@@ -273,7 +185,7 @@ def prepare_lines(lines, remove_prompt=False):
         ),
         pytest.param(
             '"""inverted quotes"""',
-            ['"""'],
+            '"""',
             '>>> """inverted quotes"""',
             id="triple-quoted string with inverted quotes",
         ),
@@ -284,7 +196,7 @@ def prepare_lines(lines, remove_prompt=False):
                     pass
                 """
             ),
-            [None, None, None],
+            None,
             textwrap.dedent(
                 """\
                 >>> def myfunc(arg1, arg2):
@@ -301,13 +213,13 @@ def prepare_lines(lines, remove_prompt=False):
 
                 """
             ),
-            [None, None],
+            None,
             ">>> a = 1",
             id="trailing newline at the end of a normal line",
         ),
         pytest.param(
             "# this is not a block:",
-            [None],
+            None,
             ">>> # this is not a block:",
             id="trailing colon at the end of a comment",
         ),
@@ -321,7 +233,7 @@ def prepare_lines(lines, remove_prompt=False):
                     '''
                 """
             ),
-            [None, "'''", "'''", "'''", "'''", None],
+            "'''",
             textwrap.dedent(
                 """\
                 >>> def f(arg1, arg2):
@@ -336,10 +248,28 @@ def prepare_lines(lines, remove_prompt=False):
         ),
         pytest.param(
             "s = '''triple-quoted string'''",
-            [None, "'''", None],
+            "'''",
             ">>> s = '''triple-quoted string'''",
             id="moved triple-quoted string",
-            marks=[pytest.mark.skip(reason="to be fixed")],
+        ),
+        pytest.param(
+            textwrap.dedent(
+                '''\
+                def f(arg1, arg2):
+                    """ docstring """
+                    s = "trailing empty string"""
+                '''
+            ),
+            "'''",
+            textwrap.dedent(
+                """\
+                >>> def f(arg1, arg2):
+                ...     ''' docstring '''
+                ...     s = "trailing empty string\"""
+                ...
+                """.rstrip()
+            ),
+            id="docstring and trailing empty string",
         ),
     ),
 )

--- a/blackdoc/tests/test_doctest.py
+++ b/blackdoc/tests/test_doctest.py
@@ -16,6 +16,28 @@ from .data.doctest import lines
         pytest.param("'''a'''", "'''", id="single quotes"),
         pytest.param('"""a"""', '"""', id="double quotes"),
         pytest.param('"a"""', None, id="trailing empty string"),
+        pytest.param(
+            textwrap.dedent(
+                """\
+                '''
+                multiple lines
+                '''
+                """
+            ).rstrip(),
+            "'''",
+            id="multiple lines single quotes",
+        ),
+        pytest.param(
+            textwrap.dedent(
+                '''\
+                """
+                multiple lines
+                """
+                '''
+            ).rstrip(),
+            '"""',
+            id="multiple lines double quotes",
+        ),
     ),
 )
 def test_detect_docstring_quotes(string, expected):

--- a/blackdoc/tests/test_doctest.py
+++ b/blackdoc/tests/test_doctest.py
@@ -250,7 +250,25 @@ def prepare_lines(lines, remove_prompt=False):
             "s = '''triple-quoted string'''",
             "'''",
             ">>> s = '''triple-quoted string'''",
-            id="moved triple-quoted string",
+            id="triple-quoted string",
+        ),
+        pytest.param(
+            textwrap.dedent(
+                """\
+                s = '''
+                    triple-quoted string
+                '''
+                """
+            ).rstrip(),
+            "'''",
+            textwrap.dedent(
+                """\
+                >>> s = '''
+                ...     triple-quoted string
+                ... '''
+                """.rstrip(),
+            ),
+            id="multi-line triple-quoted string",
         ),
         pytest.param(
             textwrap.dedent(

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -2,7 +2,7 @@ Changelog
 =========
 v0.4.0 (*unreleased*)
 ---------------------
-
+- replace docstrings by modifying by token (:pull:`144`)
 
 v0.3.6 (25 August 2022)
 -----------------------

--- a/doc/directory/file.py
+++ b/doc/directory/file.py
@@ -7,6 +7,22 @@ doctests:
 ...     "f", "g",'h', "i", "j", "k",'l', 'm',
 ...                                          }
 
+>>> s = (
+...     "a"
+...     + "b"
+... )
+
+>>> def f():
+...     '''nested docstring
+...
+...     parameter documentation
+...     '''
+...
+...     s = (
+...         '''triple-quoted string'''
+...     )
+...
+
 ipython:
 In [1]: d= { "a": 0, "b": 1, "c": 2,
    ...: "d": 3, "e": 4, "f": 5, "g": 6,

--- a/doc/directory/reformatted.py
+++ b/doc/directory/reformatted.py
@@ -21,6 +21,17 @@ doctests:
 ...     "m",
 ... }
 
+>>> s = "a" + "b"
+
+>>> def f():
+...     '''nested docstring
+...
+...     parameter documentation
+...     '''
+...
+...     s = '''triple-quoted string'''
+...
+
 ipython:
 In [1]: d = {"a": 0, "b": 1, "c": 2, "d": 3, "e": 4, "f": 5, "g": 6, "h": 7, "i": 8, "j": 9}
 """


### PR DESCRIPTION
This is hopefully much more robust than all of the previous attempts because we're actually extracting just the triple-quoted strings from the reformatted code, and before adding prompts.

 - [x] Closes #142
 - [x] Tests added
 - [x] Passes `pre-commit run --all-files`
 - [x] User visible changes (including notable bug fixes) are documented in `changelog.rst`