### PR TITLE
use the `doctest` formatter for doctest lines in rst code blocks

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -2,7 +2,7 @@ Changelog
 =========
 v0.3.8 (*unreleased*)
 ---------------------
-
+- use the `doctest` formatter for doctest lines in `rst` code blocks (:issue:`150`, :pull:`151`)
 
 v0.3.7 (13 September 2022)
 --------------------------

--- a/doc/directory/file.rst
+++ b/doc/directory/file.rst
@@ -15,6 +15,18 @@ more code:
             iterable2, iterable3, iterable4)):
         pass
 
+doctest code:
+
+>>> 4*10
+40
+
+in a code block:
+
+.. code:: python
+
+   >>> ', '.join( ['15','30'] )
+   15, 30
+
 executed code:
 
 .. ipython:: python

--- a/doc/directory/reformatted.rst
+++ b/doc/directory/reformatted.rst
@@ -17,6 +17,18 @@ more code:
     ):
         pass
 
+doctest code:
+
+>>> 4 * 10
+40
+
+in a code block:
+
+.. code:: python
+
+   >>> ", ".join(["15", "30"])
+   15, 30
+
 executed code:
 
 .. ipython:: python


### PR DESCRIPTION
- [x] Closes #150
- [x] Tests added
- [x] Passes `pre-commit run --all-files`
- [ ] User visible changes (including notable bug fixes) are documented in `changelog.rst`