### PR TITLE
rewrite the `rst` tests

### DIFF
--- a/blackdoc/tests/test_rst.py
+++ b/blackdoc/tests/test_rst.py
@@ -298,34 +298,53 @@ def test_extraction_func(code, expected):
 
 
 @pytest.mark.parametrize(
-    "code,directive,expected",
+    ("code", "directive", "expected"),
     (
         pytest.param(
-            textwrap.dedent("\n".join(data.lines[11:15])),
+            "10 * 5",
             {
                 "name": "code",
                 "language": "python",
-                "options": (":okwarning:",),
+                "options": (),
                 "prompt_length": 3,
             },
-            textwrap.dedent("\n".join(data.lines[8:15])),
+            textwrap.dedent(
+                """\
+                .. code:: python
+
+                   10 * 5
+                """.rstrip()
+            ),
             id="code",
         ),
         pytest.param(
-            textwrap.dedent("\n".join(data.lines[19:24])),
+            "10 * 5",
             {
                 "name": "code-block",
                 "language": "python",
-                "options": (),
+                "options": (":okwarning:",),
                 "prompt_length": 4,
             },
-            textwrap.dedent("\n".join(data.lines[17:24])),
-            id="code_block",
+            textwrap.dedent(
+                """\
+                .. code-block:: python
+                    :okwarning:
+
+                    10 * 5
+                """.rstrip()
+            ),
+            id="code-block_with_options",
         ),
         pytest.param(
-            textwrap.dedent("\n".join(data.lines[29:34])),
+            "10 * 5",
             {"name": "ipython", "language": None, "options": (), "prompt_length": 4},
-            textwrap.dedent("\n".join(data.lines[27:34])),
+            textwrap.dedent(
+                """\
+                .. ipython::
+
+                    10 * 5
+                """.rstrip()
+            ),
             id="ipython",
         ),
     ),

--- a/blackdoc/tests/test_rst.py
+++ b/blackdoc/tests/test_rst.py
@@ -165,7 +165,34 @@ def test_detection_func(string, expected):
     "code,expected",
     (
         pytest.param(
-            textwrap.dedent("\n".join(data.lines[8:15])),
+            textwrap.dedent(
+                """\
+                .. code:: python
+
+                   10 * 5
+                """.rstrip()
+            ),
+            (
+                {
+                    "name": "code",
+                    "language": "python",
+                    "options": (),
+                    "prompt_length": 3,
+                    "n_header_lines": 2,
+                },
+                "10 * 5",
+            ),
+            id="code",
+        ),
+        pytest.param(
+            textwrap.dedent(
+                """\
+                .. code:: python
+                   :okwarning:
+
+                   10 * 5
+                """.rstrip()
+            ),
             (
                 {
                     "name": "code",
@@ -174,26 +201,39 @@ def test_detection_func(string, expected):
                     "prompt_length": 3,
                     "n_header_lines": 3,
                 },
-                textwrap.dedent("\n".join(data.lines[11:15])),
+                "10 * 5",
             ),
-            id="code",
+            id="code_with_options",
         ),
         pytest.param(
-            textwrap.dedent("\n".join(data.lines[17:24])),
+            textwrap.dedent(
+                """\
+                .. code-block:: python
+
+                   10 * 5
+                """.rstrip()
+            ),
             (
                 {
                     "name": "code-block",
                     "language": "python",
                     "options": (),
-                    "prompt_length": 4,
+                    "prompt_length": 3,
                     "n_header_lines": 2,
                 },
-                textwrap.dedent("\n".join(data.lines[19:24])),
+                "10 * 5",
             ),
-            id="code_block",
+            id="code-block",
         ),
         pytest.param(
-            textwrap.dedent("\n".join(data.lines[27:34])),
+            textwrap.dedent(
+                """\
+                .. ipython::
+
+                    %%time
+                    10 * 5
+                """.rstrip()
+            ),
             (
                 {
                     "name": "ipython",
@@ -202,7 +242,12 @@ def test_detection_func(string, expected):
                     "prompt_length": 4,
                     "n_header_lines": 2,
                 },
-                rst.hide_magic(textwrap.dedent("\n".join(data.lines[29:34]))),
+                textwrap.dedent(
+                    """\
+                    # <ipython-magic>%%time
+                    10 * 5
+                    """.rstrip()
+                ),
             ),
             id="ipython",
         ),
@@ -210,9 +255,28 @@ def test_detection_func(string, expected):
             textwrap.dedent(
                 """\
                 .. ipython:: python
+                    10 * 5
+                """.rstrip()
+            ),
+            (
+                {
+                    "name": "ipython",
+                    "language": "python",
+                    "options": (),
+                    "prompt_length": 4,
+                    "n_header_lines": 2,
+                },
+                "10 * 5",
+            ),
+            id="missing_eof_line",
+        ),
+        pytest.param(
+            textwrap.dedent(
+                """\
+                .. ipython:: python
                     print("abc")
-                """
-            ).rstrip(),
+                """.rstrip()
+            ),
             (
                 {
                     "name": "ipython",
@@ -223,26 +287,7 @@ def test_detection_func(string, expected):
                 },
                 'print("abc")',
             ),
-            id="missing sep and eof line",
-        ),
-        pytest.param(
-            textwrap.dedent(
-                """\
-                .. ipython:: python
-                    print("abc")
-                """
-            ),
-            (
-                {
-                    "name": "ipython",
-                    "language": "python",
-                    "options": (),
-                    "prompt_length": 4,
-                    "n_header_lines": 2,
-                },
-                "\n".join(['print("abc")', ""]),
-            ),
-            id="missing sep line",
+            id="missing_sep_line",
         ),
     ),
 )


### PR DESCRIPTION
The tests in their current state are in pretty bad shape: they use line ranges from the test data. This makes it really hard to follow what the do (that test data should only be used for integration tests).

- [x] part of #2
- [x] Tests added
- [x] Passes `pre-commit run --all-files`