### PR TITLE
don't drop / split leading comments and decorators

### DIFF
--- a/blackdoc/formats/doctest.py
+++ b/blackdoc/formats/doctest.py
@@ -196,6 +196,9 @@ def split_by_statement(code_unit):
             # https://bugs.python.org/issue16806
             n_lines = len(node.value.s.split("\n"))
             lineno = node.lineno - n_lines + 1
+        elif isinstance(node, (ast.FunctionDef, ast.ClassDef)):
+            linenos = [node.lineno] + [dec.lineno for dec in node.decorator_list]
+            lineno = min(linenos)
         else:
             lineno = node.lineno
 

--- a/blackdoc/formats/doctest.py
+++ b/blackdoc/formats/doctest.py
@@ -211,6 +211,8 @@ def split_by_statement(code_unit):
         return [lines]
 
     indices = [lineno(obj) - 1 for obj in content]
+    # make sure comments are included
+    indices[0] = 0
     slices = more_itertools.zip_offset(indices, indices, offsets=(0, 1), longest=True)
     return [lines[start:stop] for start, stop in slices]
 

--- a/blackdoc/tests/test_doctest.py
+++ b/blackdoc/tests/test_doctest.py
@@ -262,6 +262,79 @@ def prepare_lines(lines, remove_prompt=False):
         pytest.param(
             textwrap.dedent(
                 """\
+                # comment
+                print("abc")
+                """
+            ),
+            None,
+            textwrap.dedent(
+                """\
+                >>> # comment
+                ... print("abc")
+                """.rstrip()
+            ),
+            id="multiple lines with comment",
+        ),
+        pytest.param(
+            textwrap.dedent(
+                """\
+                # comment
+                def func():
+                    pass
+                """
+            ),
+            None,
+            textwrap.dedent(
+                """\
+                >>> # comment
+                ... def func():
+                ...     pass
+                ...
+                """.rstrip()
+            ),
+            id="multiple lines comment before block",
+        ),
+        pytest.param(
+            textwrap.dedent(
+                """\
+                @decorator
+                def func():
+                    pass
+                """
+            ),
+            None,
+            textwrap.dedent(
+                """\
+                >>> @decorator
+                ... def func():
+                ...     pass
+                ...
+                """.rstrip()
+            ),
+            id="multiple lines function decorator",
+        ),
+        pytest.param(
+            textwrap.dedent(
+                """\
+                @decorator
+                class A:
+                    pass
+                """
+            ),
+            None,
+            textwrap.dedent(
+                """\
+                >>> @decorator
+                ... class A:
+                ...     pass
+                ...
+                """.rstrip()
+            ),
+            id="multiple lines class decorator",
+        ),
+        pytest.param(
+            textwrap.dedent(
+                """\
                 '''
                 docstring content
                 '''

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -4,7 +4,7 @@ v0.3.8 (*unreleased*)
 ---------------------
 - use the ``doctest`` formatter for doctest lines in ``rst`` code blocks (:issue:`150`, :pull:`151`)
 - drop support for ``python=3.6`` (:pull:`153`)
-- split chained statements into multiple ``doctest`` lines (:issue:`143`, :pull:`155`)
+- split chained statements into multiple ``doctest`` lines (:issue:`143`, :pull:`155`, :pull:`158`)
 - replace the custom color formatting code with `rich <https://github.com/textualize/rich>`_
   (:issue:`146`, :pull:`157`).
 

--- a/doc/directory/file.rst
+++ b/doc/directory/file.rst
@@ -21,6 +21,11 @@ doctest code:
 40
 >>> a=1;print("abc:",a)
 abc: 1
+>>> # comment
+... a=1
+>>> @decorator
+... def f():
+...     pass
 
 in a code block:
 


### PR DESCRIPTION
In #155, support for splitting doctest lines that actually are two separate statements / expressions chained together by semicolons was added. However, decorators are not contained in `lines[lineno:end_lineno]`, and comments are not even contained in the AST. This makes sure both work fine.

- [x] Tests added
- [x] Passes `pre-commit run --all-files`
- [x] User visible changes (including notable bug fixes) are documented in `changelog.rst`