### PR TITLE
update the color scheme

### DIFF
--- a/blackdoc/__main__.py
+++ b/blackdoc/__main__.py
@@ -41,7 +41,7 @@ def format_and_overwrite(path, mode):
         if new_content == content:
             result = "unchanged"
         else:
-            err.print(f"reformatted {path}", style="bold white", highlight=False)
+            err.print(f"reformatted {path}", style="bold", highlight=False)
             result = "reformatted"
 
             with open(path, "w", encoding=encoding, newline=newline) as f:
@@ -67,7 +67,7 @@ def format_and_check(path, mode, diff=False, color=False):
         if new_content == content:
             result = "unchanged"
         else:
-            err.print(f"would reformat {path}", style="bold white", highlight=False)
+            err.print(f"would reformat {path}", style="bold", highlight=False)
 
             if diff:
                 diff_ = unified_diff(content, new_content, path)
@@ -91,7 +91,7 @@ def format_and_check(path, mode, diff=False, color=False):
 
 def process(args):
     if not args.src:
-        err.print("No Path provided. Nothing to do :sleeping:", style="bold white")
+        err.print("No Path provided. Nothing to do :sleeping:", style="bold")
         return 0
 
     selected_formats = getattr(args, "formats", None)
@@ -157,7 +157,7 @@ def process(args):
     if len(sources) == 0:
         err.print(
             "No files are present to be formatted. Nothing to do :sleeping:",
-            style="bold white",
+            style="bold",
         )
         return 0
 
@@ -202,7 +202,7 @@ def process(args):
     no_reformatting_message = "All done! :sparkles: :cake: :sparkles:"
     err.print(
         reformatted_message if return_code else no_reformatting_message,
-        style="bold white",
+        style="bold",
     )
     err.print(report, highlight=False)
     return return_code

--- a/blackdoc/__main__.py
+++ b/blackdoc/__main__.py
@@ -200,6 +200,7 @@ def process(args):
 
     error_message = "Oh no! :boom: :broken_heart: :boom:"
     no_error_message = "All done! :sparkles: :cake: :sparkles:"
+    err.print()
     err.print(
         error_message if n_error > 0 else no_error_message,
         style="bold",

--- a/blackdoc/__main__.py
+++ b/blackdoc/__main__.py
@@ -198,10 +198,10 @@ def process(args):
     else:
         return_code = 0
 
-    reformatted_message = "Oh no! :boom: :broken_heart: :boom:"
-    no_reformatting_message = "All done! :sparkles: :cake: :sparkles:"
+    error_message = "Oh no! :boom: :broken_heart: :boom:"
+    no_error_message = "All done! :sparkles: :cake: :sparkles:"
     err.print(
-        reformatted_message if return_code else no_reformatting_message,
+        error_message if n_error > 0 else no_error_message,
         style="bold",
     )
     err.print(report, highlight=False)

--- a/blackdoc/__main__.py
+++ b/blackdoc/__main__.py
@@ -41,13 +41,15 @@ def format_and_overwrite(path, mode):
         if new_content == content:
             result = "unchanged"
         else:
-            err.print(f"reformatted {path}", style="bold white")
+            err.print(f"reformatted {path}", style="bold white", highlight=False)
             result = "reformatted"
 
             with open(path, "w", encoding=encoding, newline=newline) as f:
                 f.write(new_content)
     except (black.InvalidInput, formats.InvalidFormatError) as e:
-        err.print(f"error: cannot format {path.absolute()}: {e}", style="red")
+        err.print(
+            f"error: cannot format {path.absolute()}: {e}", style="red", highlight=False
+        )
         result = "error"
 
     return result
@@ -65,7 +67,7 @@ def format_and_check(path, mode, diff=False, color=False):
         if new_content == content:
             result = "unchanged"
         else:
-            err.print(f"would reformat {path}", style="bold white")
+            err.print(f"would reformat {path}", style="bold white", highlight=False)
 
             if diff:
                 diff_ = unified_diff(content, new_content, path)
@@ -79,7 +81,9 @@ def format_and_check(path, mode, diff=False, color=False):
 
             result = "reformatted"
     except (black.InvalidInput, formats.InvalidFormatError) as e:
-        err.print(f"error: cannot format {path.absolute()}: {e}", style="red")
+        err.print(
+            f"error: cannot format {path.absolute()}: {e}", style="red", highlight=False
+        )
         result = "error"
 
     return result
@@ -200,7 +204,7 @@ def process(args):
         reformatted_message if return_code else no_reformatting_message,
         style="bold white",
     )
-    err.print(report)
+    err.print(report, highlight=False)
     return return_code
 
 

--- a/blackdoc/__main__.py
+++ b/blackdoc/__main__.py
@@ -11,7 +11,7 @@ from .colors import DiffHighlighter
 from .console import err, out
 from .diff import unified_diff
 from .files import collect_files
-from .report import report_changes, report_possible_changes, statistics
+from .report import Report
 
 diff_highlighter = DiffHighlighter()
 
@@ -182,18 +182,13 @@ def process(args):
     changed_sources = {
         source: action(source, mode, **action_kwargs) for source in sorted(sources)
     }
-    n_reformatted, n_unchanged, n_error = statistics(changed_sources)
 
-    report_formatters = {
-        "inplace": report_changes,
-        "check": report_possible_changes,
-    }
+    conditional = args.action == "check"
+    report = Report.from_sources(changed_sources, conditional=conditional)
 
-    report = report_formatters.get(args.action)(n_reformatted, n_unchanged, n_error)
-
-    if n_error > 0:
+    if report.n_error > 0:
         return_code = 123
-    elif args.action == "check" and n_reformatted > 0:
+    elif args.action == "check" and report.n_reformatted > 0:
         return_code = 1
     else:
         return_code = 0
@@ -202,7 +197,7 @@ def process(args):
     no_error_message = "All done! :sparkles: :cake: :sparkles:"
     err.print()
     err.print(
-        error_message if n_error > 0 else no_error_message,
+        error_message if report.n_error > 0 else no_error_message,
         style="bold",
     )
     err.print(report, highlight=False)

--- a/blackdoc/colors.py
+++ b/blackdoc/colors.py
@@ -9,7 +9,7 @@ trailing_whitespace_re = re.compile(r"\s+$")
 
 def line_style(lineno, line):
     if line.startswith("+++") or line.startswith("---"):
-        yield lineno, (0, len(line)), "bold white"
+        yield lineno, (0, len(line)), "bold"
     elif line.startswith("@@"):
         yield lineno, (0, len(line)), "cyan"
     elif line.startswith("+"):

--- a/blackdoc/colors.py
+++ b/blackdoc/colors.py
@@ -52,3 +52,14 @@ class DiffHighlighter(Highlighter):
 
         for (start, end), style in diff_styles(text.plain):
             text.stylize(style, start=start, end=end)
+
+
+class FileHighlighter(Highlighter):
+    highlights = {
+        r"[0-9]+ files?(?!.*fail)": "blue",
+        r"^.+fail.+$": "red",
+    }
+
+    def highlight(self, text):
+        for highlight_re, style in self.highlights.items():
+            text.highlight_regex(highlight_re, style=style)

--- a/blackdoc/colors.py
+++ b/blackdoc/colors.py
@@ -57,6 +57,7 @@ class DiffHighlighter(Highlighter):
 class FileHighlighter(Highlighter):
     highlights = {
         r"[0-9]+ files?(?!.*fail)": "blue",
+        r"^.+reformatted$": "bold",
         r"^.+fail.+$": "red",
     }
 

--- a/blackdoc/report.py
+++ b/blackdoc/report.py
@@ -1,41 +1,8 @@
-def report_changes(n_reformatted, n_unchanged, n_error):
-    def noun(n):
-        return "file" if n < 2 else "files"
+from rich.text import Text
 
-    reports = []
-    if n_reformatted > 0:
-        reports.append(
-            f"[bold][blue]{n_reformatted} {noun(n_reformatted)}[/blue] reformatted[/]",
-        )
+from .colors import FileHighlighter
 
-    if n_unchanged > 0:
-        reports.append(f"[blue]{n_unchanged} {noun(n_unchanged)}[/] left unchanged")
-
-    if n_error > 0:
-        reports.append(f"[red]{n_error} {noun(n_error)} fails to reformat[/]")
-
-    return ", ".join(reports) + "."
-
-
-def report_possible_changes(n_reformatted, n_unchanged, n_error):
-    def noun(n):
-        return "file" if n < 2 else "files"
-
-    reports = []
-    if n_reformatted > 0:
-        reports.append(
-            f"[bold][blue]{n_reformatted} {noun(n_reformatted)}[/blue] would be reformatted[/]",
-        )
-
-    if n_unchanged > 0:
-        reports.append(
-            f"[blue]{n_unchanged} {noun(n_unchanged)}[/] would be left unchanged"
-        )
-
-    if n_error > 0:
-        reports.append(f"[red]{n_error} {noun(n_error)} would fail to reformat[/]")
-
-    return ", ".join(reports) + "."
+highlighter = FileHighlighter()
 
 
 def statistics(sources):
@@ -51,3 +18,63 @@ def statistics(sources):
         raise RuntimeError(f"unknown results: {statistics.keys()}")
 
     return n_reformatted, n_unchanged, n_error
+
+
+def noun(n):
+    return "file" if n < 2 else "files"
+
+
+class Report:
+    def __init__(self, n_reformatted, n_unchanged, n_error, conditional=False):
+        self.n_reformatted = n_reformatted
+        self.n_unchanged = n_unchanged
+        self.n_error = n_error
+
+        self.conditional = conditional
+
+    @classmethod
+    def from_sources(cls, sources, conditional=False):
+        n_reformatted, n_unchanged, n_error = statistics(sources)
+
+        return cls(n_reformatted, n_unchanged, n_error, conditional=conditional)
+
+    def __repr__(self):
+        params = [
+            f"{name}={getattr(self, name)}"
+            for name in ["n_reformatted", "n_unchanged", "n_error", "conditional"]
+        ]
+        return f"Report({', '.join(params)})"
+
+    @property
+    def _reformatted_report(self):
+        if self.conditional:
+            return (
+                f"{self.n_reformatted} {noun(self.n_reformatted)} would be reformatted"
+            )
+        else:
+            return f"{self.n_reformatted} {noun(self.n_reformatted)} reformatted"
+
+    @property
+    def _unchanged_report(self):
+        if self.conditional:
+            return (
+                f"{self.n_unchanged} {noun(self.n_unchanged)} would be left unchanged"
+            )
+        else:
+            return f"{self.n_unchanged} {noun(self.n_unchanged)} left unchanged"
+
+    @property
+    def _error_report(self):
+        if self.conditional:
+            return f"{self.n_error} {noun(self.n_error)} would fail to reformat"
+        else:
+            return f"{self.n_error} {noun(self.n_error)} failed to reformat"
+
+    def __rich__(self):
+        raw_parts = [
+            self._reformatted_report,
+            self._unchanged_report,
+            self._error_report,
+        ]
+        parts = [highlighter(part) for part in raw_parts]
+        return Text(", ").join(parts) + Text(".")

--- a/blackdoc/report.py
+++ b/blackdoc/report.py
@@ -5,11 +5,11 @@ def report_changes(n_reformatted, n_unchanged, n_error):
     reports = []
     if n_reformatted > 0:
         reports.append(
-            f"[bold white]{n_reformatted} {noun(n_reformatted)} reformatted[/]",
+            f"[bold][blue]{n_reformatted} {noun(n_reformatted)}[/blue] reformatted[/]",
         )
 
     if n_unchanged > 0:
-        reports.append(f"[white]{n_unchanged} {noun(n_unchanged)} left unchanged[/]")
+        reports.append(f"[blue]{n_unchanged} {noun(n_unchanged)}[/] left unchanged")
 
     if n_error > 0:
         reports.append(f"[red]{n_error} {noun(n_error)} fails to reformat[/]")
@@ -24,12 +24,12 @@ def report_possible_changes(n_reformatted, n_unchanged, n_error):
     reports = []
     if n_reformatted > 0:
         reports.append(
-            f"[bold white]{n_reformatted} {noun(n_reformatted)} would be reformatted[/]",
+            f"[bold][blue]{n_reformatted} {noun(n_reformatted)}[/blue] would be reformatted[/]",
         )
 
     if n_unchanged > 0:
         reports.append(
-            f"[white]{n_unchanged} {noun(n_unchanged)} would be left unchanged[/]"
+            f"[blue]{n_unchanged} {noun(n_unchanged)}[/] would be left unchanged"
         )
 
     if n_error > 0:

--- a/blackdoc/tests/test_colors.py
+++ b/blackdoc/tests/test_colors.py
@@ -36,7 +36,7 @@ from blackdoc import colors
                 +++ file2 time2
                 """
             ),
-            [Span(0, 15, "bold white"), Span(16, 31, "bold white")],
+            [Span(0, 15, "bold"), Span(16, 31, "bold")],
             id="header",
         ),
         pytest.param(

--- a/blackdoc/tests/test_colors.py
+++ b/blackdoc/tests/test_colors.py
@@ -51,3 +51,55 @@ def test_diff_highlighter(text, spans):
 
     actual = diff_highlighter(text)
     assert actual.spans == spans
+
+
+@pytest.mark.parametrize(
+    ["text", "spans"],
+    (
+        pytest.param(
+            "1 file would be reformatted",
+            [Span(0, 6, "blue")],
+            id="single file conditional",
+        ),
+        pytest.param(
+            "1 file reformatted",
+            [Span(0, 6, "blue")],
+            id="single file",
+        ),
+        pytest.param(
+            "26 files would be reformatted",
+            [Span(0, 8, "blue")],
+            id="multiple files conditional",
+        ),
+        pytest.param(
+            "26 files reformatted",
+            [Span(0, 8, "blue")],
+            id="multiple files",
+        ),
+        pytest.param(
+            "1 file would fail to reformat",
+            [Span(0, 29, "red")],
+            id="failed single file conditional",
+        ),
+        pytest.param(
+            "1 file failed to reformat",
+            [Span(0, 25, "red")],
+            id="failed single file",
+        ),
+        pytest.param(
+            "15 files would fail to reformat",
+            [Span(0, 31, "red")],
+            id="failed multiple files conditional",
+        ),
+        pytest.param(
+            "15 files failed to reformat",
+            [Span(0, 27, "red")],
+            id="failed multiple files",
+        ),
+    ),
+)
+def test_file_highlighter(text, spans):
+    highlighter = colors.FileHighlighter()
+
+    actual = highlighter(text)
+    assert actual.spans == spans

--- a/blackdoc/tests/test_colors.py
+++ b/blackdoc/tests/test_colors.py
@@ -58,43 +58,63 @@ def test_diff_highlighter(text, spans):
     (
         pytest.param(
             "1 file would be reformatted",
-            [Span(0, 6, "blue")],
-            id="single file conditional",
+            [Span(0, 6, "blue"), Span(0, 27, "bold")],
+            id="single file-reformatted-conditional",
         ),
         pytest.param(
             "1 file reformatted",
-            [Span(0, 6, "blue")],
-            id="single file",
+            [Span(0, 6, "blue"), Span(0, 18, "bold")],
+            id="single file-reformatted",
         ),
         pytest.param(
             "26 files would be reformatted",
-            [Span(0, 8, "blue")],
-            id="multiple files conditional",
+            [Span(0, 8, "blue"), Span(0, 29, "bold")],
+            id="multiple files-reformatted-conditional",
         ),
         pytest.param(
             "26 files reformatted",
+            [Span(0, 8, "blue"), Span(0, 20, "bold")],
+            id="multiple files-reformatted",
+        ),
+        pytest.param(
+            "1 file would be left unchanged",
+            [Span(0, 6, "blue")],
+            id="single file-unchanged-conditional",
+        ),
+        pytest.param(
+            "1 file left unchanged",
+            [Span(0, 6, "blue")],
+            id="single file-unchanged",
+        ),
+        pytest.param(
+            "26 files would be left unchanged",
             [Span(0, 8, "blue")],
-            id="multiple files",
+            id="multiple files-unchanged-conditional",
+        ),
+        pytest.param(
+            "26 files left unchanged",
+            [Span(0, 8, "blue")],
+            id="multiple files-unchanged",
         ),
         pytest.param(
             "1 file would fail to reformat",
             [Span(0, 29, "red")],
-            id="failed single file conditional",
+            id="single file-error-conditional",
         ),
         pytest.param(
             "1 file failed to reformat",
             [Span(0, 25, "red")],
-            id="failed single file",
+            id="single file-error",
         ),
         pytest.param(
             "15 files would fail to reformat",
             [Span(0, 31, "red")],
-            id="failed multiple files conditional",
+            id="multiple files-error-conditional",
         ),
         pytest.param(
             "15 files failed to reformat",
             [Span(0, 27, "red")],
-            id="failed multiple files",
+            id="multiple files-error",
         ),
     ),
 )

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -6,7 +6,7 @@ v0.3.8 (*unreleased*)
 - drop support for ``python=3.6`` (:pull:`153`)
 - split chained statements into multiple ``doctest`` lines (:issue:`143`, :pull:`155`, :pull:`158`)
 - replace the custom color formatting code with `rich <https://github.com/textualize/rich>`_
-  (:issue:`146`, :pull:`157`).
+  (:issue:`146`, :pull:`157`, :pull:`159`).
 
 v0.3.7 (13 September 2022)
 --------------------------


### PR DESCRIPTION
This is pretty easy, now that we are using `rich`. Also, we can get rid of the somewhat complicated reporting functions and use a `rich`-aware class instead.

- [x] Passes `pre-commit run --all-files`
- [x] User visible changes (including notable bug fixes) are documented in `changelog.rst`