### PR TITLE
support reading the version from black's pre-commit mirror

### DIFF
--- a/blackdoc/autoupdate.py
+++ b/blackdoc/autoupdate.py
@@ -1,7 +1,10 @@
 import argparse
 import re
 
-version_re = re.compile(r"black\s+rev: (.+)\s+hooks:\s+- id: black")
+version_re = re.compile(
+    r"https://github.com/(?:.+)/(?:black|black-pre-commit-mirror)\s+"
+    r"rev: (.+)\s+hooks:\s+- id: black"
+)
 black_pin_re = re.compile(
     r"(- id: blackdoc.+?additional_dependencies:.+?black==)[.\w]+",
     re.DOTALL,

--- a/blackdoc/autoupdate.py
+++ b/blackdoc/autoupdate.py
@@ -23,18 +23,15 @@ def update_black_pin(content, version):
     return black_pin_re.sub(rf"\g<1>{version}", content)
 
 
-def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument("path")
-    args = parser.parse_args()
-    with open(args.path) as f:
+def main(path):
+    with open(path) as f:
         content = f.read()
 
     version = find_black_version(content)
     replaced = update_black_pin(content, version)
 
     if content != replaced:
-        with open(args.path, mode="w") as f:
+        with open(path, mode="w") as f:
             f.write(replaced)
         return 1
     else:
@@ -42,4 +39,7 @@ def main():
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    parser = argparse.ArgumentParser()
+    parser.add_argument("path")
+    args = parser.parse_args()
+    raise SystemExit(main(args.path))

--- a/blackdoc/autoupdate.py
+++ b/blackdoc/autoupdate.py
@@ -3,7 +3,7 @@ import re
 
 version_re = re.compile(
     r"https://github.com/(?:.+)/(?:black|black-pre-commit-mirror)\s+"
-    r"rev: (.+)\s+hooks:\s+- id: black"
+    r"rev: (.+)\s+hooks:(?:\s+-id: [-_a-zA-Z0-9]+)*\s+- id: (?:black|black-jupyter)"
 )
 black_pin_re = re.compile(
     r"(- id: blackdoc.+?additional_dependencies:.+?black==)[.\w]+",

--- a/blackdoc/autoupdate.py
+++ b/blackdoc/autoupdate.py
@@ -2,7 +2,7 @@ import argparse
 import re
 
 version_re = re.compile(
-    r"https://github.com/(?:.+)/(?:black|black-pre-commit-mirror)\s+"
+    r"https://github.com/psf/(?:black|black-pre-commit-mirror)\s+"
     r"rev: (.+)\s+hooks:(?:\s+-id: [-_a-zA-Z0-9]+)*\s+- id: (?:black|black-jupyter)"
 )
 black_pin_re = re.compile(

--- a/blackdoc/autoupdate.py
+++ b/blackdoc/autoupdate.py
@@ -11,6 +11,18 @@ black_pin_re = re.compile(
 )
 
 
+def find_black_version(content):
+    match = version_re.search(content)
+    if match is None:
+        raise ValueError("cannot find the black hook")
+    version = match.group(1)
+    return version
+
+
+def update_black_pin(content, version):
+    return black_pin_re.sub(rf"\g<1>{version}", content)
+
+
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("path")
@@ -18,11 +30,8 @@ def main():
     with open(args.path) as f:
         content = f.read()
 
-    match = version_re.search(content)
-    if match is None:
-        raise ValueError("cannot find the black hook")
-    version = match.group(1)
-    replaced = black_pin_re.sub(rf"\g<1>{version}", content)
+    version = find_black_version(content)
+    replaced = update_black_pin(content, version)
 
     if content != replaced:
         with open(args.path, mode="w") as f:

--- a/blackdoc/tests/test_autoupdate.py
+++ b/blackdoc/tests/test_autoupdate.py
@@ -148,3 +148,82 @@ def test_update_black_pin(content, version, expected):
     updated = autoupdate.update_black_pin(content, version)
 
     assert updated == expected
+
+
+@pytest.mark.parametrize(
+    ["content", "expected"],
+    (
+        pytest.param(
+            """\
+        hooks:
+        - repo: https://github.com/psf/black
+          rev: 22.0.1
+          hooks:
+          - id: black
+
+        - repo: https://github.com/keewis/blackdoc
+          rev: 3.9.0
+          hooks:
+            - id: blackdoc
+              additional_dependencies: ["black==22.0.1"]
+        """,
+            """\
+        hooks:
+        - repo: https://github.com/psf/black
+          rev: 22.0.1
+          hooks:
+          - id: black
+
+        - repo: https://github.com/keewis/blackdoc
+          rev: 3.9.0
+          hooks:
+            - id: blackdoc
+              additional_dependencies: ["black==22.0.1"]
+        """,
+        ),
+        pytest.param(
+            """\
+        hooks:
+        - repo: https://github.com/psf/black
+          rev: 23.10.0
+          hooks:
+          - id: black
+
+        - repo: https://github.com/keewis/blackdoc
+          rev: 3.9.0
+          hooks:
+            - id: blackdoc
+              additional_dependencies: ["black==22.0.1"]
+        """,
+            """\
+        hooks:
+        - repo: https://github.com/psf/black
+          rev: 23.10.0
+          hooks:
+          - id: black
+
+        - repo: https://github.com/keewis/blackdoc
+          rev: 3.9.0
+          hooks:
+            - id: blackdoc
+              additional_dependencies: ["black==23.10.0"]
+        """,
+        ),
+    ),
+)
+def test_main(tmp_path, content, expected):
+    path = tmp_path.joinpath(".pre-commit-config.yaml")
+    path.write_text(content)
+
+    stat = path.stat()
+
+    return_value = autoupdate.main(path)
+
+    updated = path.read_text()
+
+    assert updated == expected
+    if content == expected:
+        assert path.stat() == stat
+        assert return_value == 0
+    else:
+        assert return_value == 1

--- a/blackdoc/tests/test_autoupdate.py
+++ b/blackdoc/tests/test_autoupdate.py
@@ -1,0 +1,70 @@
+import pytest
+
+from blackdoc import autoupdate
+
+
+@pytest.mark.parametrize(
+    ["content", "expected"],
+    (
+        pytest.param(
+            """\
+            - repo: https://github.com/psf/black
+              rev: 23.1.0
+              hooks:
+                - id: black
+            """,
+            "23.1.0",
+        ),
+        pytest.param(
+            """\
+            - repo: https://github.com/psf/black
+              rev: 22.7.1
+              hooks:
+                - id: black-jupyter
+            """,
+            "22.7.1",
+        ),
+        pytest.param(
+            """\
+            - repo: https://github.com/psf/black-pre-commit-mirror
+              rev: 23.10.1
+              hooks:
+                - id: black
+            """,
+            "23.10.1",
+        ),
+        pytest.param(
+            """\
+            - repo: https://github.com/psf/black-pre-commit-mirror
+              rev: 22.9.10
+              hooks:
+                - id: black-jupyter
+            """,
+            "22.9.10",
+        ),
+        pytest.param(
+            """\
+            - repo: https://github.com/psf/black-pre-commit-mirror
+              rev: 24.12.1
+              hooks:
+                - id: black
+                - id: black-jupyter
+            """,
+            "24.12.1",
+        ),
+        pytest.param(
+            """\
+            - repo: https://github.com/psf/black-pre-commit-mirror
+              rev: 24.12.1
+              hooks:
+                - id: black-jupyter
+                - id: black
+            """,
+            "24.12.1",
+        ),
+    ),
+)
+def test_find_black_version(content, expected):
+    version = autoupdate.find_black_version(content)
+
+    assert version == expected

--- a/blackdoc/tests/test_autoupdate.py
+++ b/blackdoc/tests/test_autoupdate.py
@@ -68,3 +68,83 @@ def test_find_black_version(content, expected):
     version = autoupdate.find_black_version(content)
 
     assert version == expected
+
+
+@pytest.mark.parametrize(
+    ["content", "version", "expected"],
+    (
+        pytest.param(
+            """\
+            - repo: https://github.com/pre-commit/pre-commit-hooks
+              rev: 4.4.0
+              hooks:
+                - id: trailing-whitespace
+                - id: end-of-file-fixer
+
+            - repo: https://github.com/keewis/blackdoc
+              rev: 3.8.0
+              hooks:
+                - id: blackdoc
+                  additional_dependencies: ["black==22.10.0"]
+                - id: blackdoc-autoupdate-black
+            """,
+            "23.3.0",
+            """\
+            - repo: https://github.com/pre-commit/pre-commit-hooks
+              rev: 4.4.0
+              hooks:
+                - id: trailing-whitespace
+                - id: end-of-file-fixer
+
+            - repo: https://github.com/keewis/blackdoc
+              rev: 3.8.0
+              hooks:
+                - id: blackdoc
+                  additional_dependencies: ["black==23.3.0"]
+                - id: blackdoc-autoupdate-black
+            """,
+        ),
+        pytest.param(
+            """\
+            - repo: https://github.com/keewis/blackdoc
+              rev: 3.8.0
+              hooks:
+                - id: blackdoc
+                  additional_dependencies: ["black==22.10.0"]
+                - id: blackdoc-autoupdate-black
+            """,
+            "21.5.1",
+            """\
+            - repo: https://github.com/keewis/blackdoc
+              rev: 3.8.0
+              hooks:
+                - id: blackdoc
+                  additional_dependencies: ["black==21.5.1"]
+                - id: blackdoc-autoupdate-black
+            """,
+        ),
+        pytest.param(
+            """\
+            - repo: https://github.com/keewis/blackdoc
+              rev: 3.8.0
+              hooks:
+                - id: blackdoc
+                  additional_dependencies: ["black==22.10.0"]
+                - id: blackdoc-autoupdate-black
+            """,
+            "23.7.12",
+            """\
+            - repo: https://github.com/keewis/blackdoc
+              rev: 3.8.0
+              hooks:
+                - id: blackdoc
+                  additional_dependencies: ["black==23.7.12"]
+                - id: blackdoc-autoupdate-black
+            """,
+        ),
+    ),
+)
+def test_update_black_pin(content, version, expected):
+    updated = autoupdate.update_black_pin(content, version)
+
+    assert updated == expected


### PR DESCRIPTION
`black` somewhat recently added a mirror that pulls in the `mypyc` compiled wheels from PyPI, making it quite a bit faster. The autoupdate / version sync hook only supported pulling the version from the standard repo hook entry in the `pre-commit` configuration.

- [x] Passes `pre-commit run --all-files`
- [x] Tests added
- [ ] User visible changes (including notable bug fixes) are documented in `changelog.rst`

<!--
By default, the upstream-dev CI is only run when triggered by the github website (`workflow_dispatch`)
or if it was run on schedule. To run it on a commit of a pull request (`pull_request`), include
the `[test-upstream]` tag in the summary line of the commit message.

For changes that are not covered by the CI please use the `[skip-ci]` tag to avoid running the
normal CI.
-->