### PR TITLE
document the `pre-commit` hooks

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,3 +72,36 @@ It is also possible to use the entrypoint script:
 .. code:: bash
 
     blackdoc --help
+
+pre-commit
+----------
+This repository defines a ``pre-commit`` hook:
+
+.. code:: yaml
+
+   hooks:
+   ...
+   - repo: https://github.com/keewis/blackdoc
+     rev: 3.8.0
+     hooks:
+     - id: blackdoc
+
+It is recommended to *pin* ``black`` in order to avoid having different versions for each contributor. To automatically synchronize this pin with the version of the ``black`` hook, use the ``blackdoc-autoupdate-black`` hook:
+
+.. code:: yaml
+
+   hooks:
+   ...
+   - repo: https://github.com/psf/black
+     rev: 23.10.1
+     hooks:
+     - id: black
+   ...
+   - repo: https://github.com/keewis/blackdoc
+     rev: 3.8.0
+     hooks:
+     - id: blackdoc
+       additional_dependencies: ["black==23.10.1"]
+     - id: blackdoc-autoupdate-black
+
+Note that this hook is *not* run on ``pre-commit autoupdate``.

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -2,7 +2,8 @@ Changelog
 =========
 v0.3.9 (*unreleased*)
 ---------------------
-
+- support synchronizing the version of the ``black`` hook in more cases (:pull:`180`)
+- document the ``pre-commit`` hooks (:issue:`176`, :pull:`181`)
 
 v0.3.8 (03 November 2022)
 -------------------------

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -1,5 +1,7 @@
 Usage
------
+=====
+command-line interface
+----------------------
 **blackdoc** tries to copy as much of the CLI of **black** as
 possible. This means that most calls to **black** can be directly
 translated to **blackdoc**:
@@ -60,3 +62,36 @@ the result is::
     2 files would be reformatted.
 
 with a non-zero exit status.
+
+pre-commit
+----------
+The repository also defines a ``pre-commit`` hook:
+
+.. code:: yaml
+
+   hooks:
+   ...
+   - repo: https://github.com/keewis/blackdoc
+     rev: 3.8.0
+     hooks:
+     - id: blackdoc
+
+It is recommended to *pin* ``black`` in order to avoid having different versions for each contributor. To automatically synchronize this pin with the version of the ``black`` hook, use the ``blackdoc-autoupdate-black`` hook:
+
+.. code:: yaml
+
+   hooks:
+   ...
+   - repo: https://github.com/psf/black
+     rev: 23.10.1
+     hooks:
+     - id: black
+   ...
+   - repo: https://github.com/keewis/blackdoc
+     rev: 3.8.0
+     hooks:
+     - id: blackdoc
+       additional_dependencies: ["black==23.10.1"]
+     - id: blackdoc-autoupdate-black
+
+Note that this hook is *not* run on ``pre-commit autoupdate``.


### PR DESCRIPTION
- [x] Closes #176
- [x] Passes `pre-commit run --all-files`
- [x] User visible changes (including notable bug fixes) are documented in `changelog.rst`

<!--
By default, the upstream-dev CI is only run when triggered by the github website (`workflow_dispatch`)
or if it was run on schedule. To run it on a commit of a pull request (`pull_request`), include
the `[test-upstream]` tag in the summary line of the commit message.

For changes that are not covered by the CI please use the `[skip-ci]` tag to avoid running the
normal CI.
-->