### PR TITLE
refactor the ipython tests

### DIFF
--- a/blackdoc/tests/test_ipython.py
+++ b/blackdoc/tests/test_ipython.py
@@ -51,40 +51,71 @@ def test_detection_func(lines, expected):
 
 
 @pytest.mark.parametrize(
-    "line,expected",
+    ["line", "expected"],
     (
         pytest.param(
-            textwrap.dedent(data.lines[9]),
-            ({"count": 2}, textwrap.dedent(data.lines[9])[8:]),
+            "In [2]: file",
+            ({"count": 2}, "file"),
             id="single_line",
         ),
         pytest.param(
-            textwrap.dedent("\n".join(data.lines[4:8])),
-            ({"count": 1}, "\n".join(line[12:] for line in data.lines[4:8])),
+            textwrap.dedent(
+                """\
+            In [1]: file = open(
+               ...:     "very_long_filepath",
+               ...:     mode="a",
+               ...: )
+            """.rstrip()
+            ),
+            (
+                {"count": 1},
+                "\n".join(
+                    [
+                        "file = open(",
+                        '    "very_long_filepath",',
+                        '    mode="a",',
+                        ")",
+                    ]
+                ),
+            ),
             id="multiple_lines",
         ),
         pytest.param(
-            textwrap.dedent("\n".join(data.lines[18:20])),
+            textwrap.dedent(
+                """\
+            In [4]: %%time
+               ...: file.close()
+            """.rstrip()
+            ),
             (
                 {"count": 4},
-                "\n".join(
-                    line[12:]
-                    if not ipython.magic_re.match(line[12:])
-                    else f"# {ipython.magic_comment}{line[12:]}"
-                    for line in data.lines[18:20]
+                textwrap.dedent(
+                    f"""\
+                # {ipython.magic_comment}%%time
+                file.close()
+                """.rstrip()
                 ),
             ),
             id="lines_with_cell_magic",
         ),
         pytest.param(
-            textwrap.dedent("\n".join(data.lines[21:25])),
+            textwrap.dedent(
+                """\
+                In [5]: @savefig simple.png width=4in
+                   ...: @property
+                   ...: def my_property(self):
+                   ...:     pass
+                """.rstrip()
+            ),
             (
                 {"count": 5},
-                "\n".join(
-                    line[12:]
-                    if not ipython.magic_re.match(line[12:])
-                    else f"# {ipython.magic_comment}{line[12:]}"
-                    for line in data.lines[21:25]
+                textwrap.dedent(
+                    f"""\
+                    # {ipython.magic_comment}@savefig simple.png width=4in
+                    @property
+                    def my_property(self):
+                        pass
+                    """.rstrip()
                 ),
             ),
             id="lines_with_line_decorator",

--- a/blackdoc/tests/test_ipython.py
+++ b/blackdoc/tests/test_ipython.py
@@ -10,15 +10,33 @@ from .data import ipython as data
 
 
 @pytest.mark.parametrize(
-    "lines,expected",
+    ["lines", "expected"],
     (
-        pytest.param(data.lines[0], None, id="no_line"),
+        pytest.param("xyz def", None, id="no_line"),
         pytest.param(
-            data.lines[9], ((1, 2), ipython.name, data.lines[9]), id="single_line"
+            "    In [2]: file",
+            ((1, 2), ipython.name, "    In [2]: file"),
+            id="single_line",
         ),
         pytest.param(
-            data.lines[4:8],
-            ((1, 5), ipython.name, "\n".join(data.lines[4:8])),
+            [
+                "In [1]: file = open(",
+                '   ...:     "very_long_filepath",',
+                '   ...:     mode="a",',
+                "   ...: )",
+            ],
+            (
+                (1, 5),
+                ipython.name,
+                textwrap.dedent(
+                    """\
+            In [1]: file = open(
+               ...:     "very_long_filepath",
+               ...:     mode="a",
+               ...: )
+            """.rstrip()
+                ),
+            ),
             id="multiple_lines",
         ),
     ),

--- a/blackdoc/tests/test_ipython.py
+++ b/blackdoc/tests/test_ipython.py
@@ -129,40 +129,63 @@ def test_extraction_func(line, expected):
 
 
 @pytest.mark.parametrize(
-    "line,count,expected",
+    ["line", "count", "expected"],
     (
+        pytest.param("file", 2, "In [2]: file", id="single_line"),
         pytest.param(
-            textwrap.dedent(data.lines[9])[8:],
-            2,
-            textwrap.dedent(data.lines[9]),
-            id="single_line",
-        ),
-        pytest.param(
-            "\n".join(line[12:] for line in data.lines[4:8]),
+            textwrap.dedent(
+                """\
+                file = open(
+                    "very_long_filepath",
+                    mode="a",
+                )
+                """.rstrip()
+            ),
             1,
-            textwrap.dedent("\n".join(data.lines[4:8])),
+            textwrap.dedent(
+                """\
+                In [1]: file = open(
+                   ...:     "very_long_filepath",
+                   ...:     mode="a",
+                   ...: )
+                """.rstrip()
+            ),
             id="multiple_lines",
         ),
         pytest.param(
-            "\n".join(
-                line[12:]
-                if not ipython.magic_re.match(line)
-                else f"#{ipython.magic_comment}{line[12:]}"
-                for line in data.lines[18:20]
+            textwrap.dedent(
+                f"""\
+                # {ipython.magic_comment}%%time
+                file.close()
+                """.rstrip()
             ),
             4,
-            textwrap.dedent("\n".join(data.lines[18:20])),
+            textwrap.dedent(
+                """\
+                In [4]: %%time
+                   ...: file.close()
+                """.rstrip()
+            ),
             id="lines_with_cell_magic",
         ),
         pytest.param(
-            "\n".join(
-                line[12:]
-                if not ipython.magic_re.match(line)
-                else f"#{ipython.magic_comment}{line[12:]}"
-                for line in data.lines[21:25]
+            textwrap.dedent(
+                f"""\
+                # {ipython.magic_comment}@savefig simple.png width=4in
+                @property
+                def my_property(self):
+                    pass
+                """.rstrip()
             ),
             5,
-            textwrap.dedent("\n".join(data.lines[21:25])),
+            textwrap.dedent(
+                """\
+                In [5]: @savefig simple.png width=4in
+                   ...: @property
+                   ...: def my_property(self):
+                   ...:     pass
+                """.rstrip()
+            ),
             id="lines_with_line_decorator",
         ),
     ),


### PR DESCRIPTION
Just like #152 and #156, this refactors the tests to directly pass the input and expected output instead of using the test metadata.

- [x] Passes `pre-commit run --all-files`

<!--
By default, the upstream-dev CI is only run when triggered by the github website (`workflow_dispatch`)
or if it was run on schedule. To run it on a commit of a pull request (`pull_request`), include
the `[test-upstream]` tag in the summary line of the commit message.

For changes that are not covered by the CI please use the `[skip-ci]` tag to avoid running the
normal CI.
-->