### PR TITLE
officially support python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -4,6 +4,7 @@ v0.3.9 (*unreleased*)
 ---------------------
 - support synchronizing the version of the ``black`` hook in more cases (:pull:`180`)
 - document the ``pre-commit`` hooks (:issue:`176`, :pull:`181`)
+- officially support python 3.12 (:pull:`185`)
 
 v0.3.8 (03 November 2022)
 -------------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ classifiers =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3 :: Only
     Topic :: Documentation
     Topic :: Software Development :: Documentation


### PR DESCRIPTION
- [x] Passes `pre-commit run --all-files`
- [x] User visible changes (including notable bug fixes) are documented in `changelog.rst`

<!--
By default, the upstream-dev CI is only run when triggered by the github website (`workflow_dispatch`)
or if it was run on schedule. To run it on a commit of a pull request (`pull_request`), include
the `[test-upstream]` tag in the summary line of the commit message.

For changes that are not covered by the CI please use the `[skip-ci]` tag to avoid running the
normal CI.
-->