### PR TITLE
officially drop support for running on python 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:

--- a/blackdoc/__init__.py
+++ b/blackdoc/__init__.py
@@ -1,7 +1,4 @@
-try:
-    from importlib.metadata import version
-except ImportError:
-    from importlib_metadata import version
+from importlib.metadata import version
 
 from .blacken import blacken
 from .classification import detect_format

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -5,6 +5,7 @@ v0.3.9 (*unreleased*)
 - support synchronizing the version of the ``black`` hook in more cases (:pull:`180`)
 - document the ``pre-commit`` hooks (:issue:`176`, :pull:`181`)
 - officially support python 3.12 (:pull:`185`)
+- drop support for running on python 3.7 (:pull:`186`)
 
 v0.3.8 (03 November 2022)
 -------------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,6 @@ python_requires = >=3.8
 install_requires =
     black
     more_itertools
-    importlib-metadata; python_version < "3.8"
     tomli
     pathspec
     rich

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ classifiers =
 
 [options]
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.8
 install_requires =
     black
     more_itertools

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,6 @@ classifiers =
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent
     Programming Language :: Python
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10


### PR DESCRIPTION
`black` did this in `23.9.0`.

- [x] Passes `pre-commit run --all-files`
- [x] User visible changes (including notable bug fixes) are documented in `changelog.rst`

<!--
By default, the upstream-dev CI is only run when triggered by the github website (`workflow_dispatch`)
or if it was run on schedule. To run it on a commit of a pull request (`pull_request`), include
the `[test-upstream]` tag in the summary line of the commit message.

For changes that are not covered by the CI please use the `[skip-ci]` tag to avoid running the
normal CI.
-->