### PR TITLE
move nightly to `python=3.12`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,7 +16,9 @@ concurrency:
 jobs:
   detect-test-upstream-trigger:
     name: "Detect CI Trigger: [test-upstream]"
-    if: github.event_name == 'push' || github.event_name == 'pull_request'
+    if: |
+      github.repository_owner == 'keewis'
+      && (github.event_name == 'push' || github.event_name == 'pull_request')
     runs-on: ubuntu-latest
     outputs:
       triggered: ${{ steps.detect-trigger.outputs.trigger-found }}
@@ -36,11 +38,14 @@ jobs:
 
     if: |
       always()
-      && github.repository == 'keewis/blackdoc'
+      && github.repository_owner == 'keewis'
       && (
-        github.event_name == 'schedule'
-        || github.event_name == 'workflow_dispatch'
+        (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
         || needs.detect-test-upstream-trigger.outputs.triggered == 'true'
+        || (
+            github.event_name == 'pull_request'
+            && contains(github.event.pull_request.labels.*.name, 'run-upstream')
+        )
       )
 
     strategy:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.12"]
 
     outputs:
       artifacts_availability: ${{ steps.status.outputs.ARTIFACTS_AVAILABLE }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -97,6 +97,6 @@ jobs:
           failure()
           && steps.tests.outcome == 'failure'
           && github.event_name == 'schedule'
-        uses: xarray-contrib/issue-from-pytest-log@v0.1
+        uses: xarray-contrib/issue-from-pytest-log@v1
         with:
           log-path: pytest-log.jsonl


### PR DESCRIPTION
- [x] Passes `pre-commit run --all-files`

<!--
By default, the upstream-dev CI is only run when triggered by the github website (`workflow_dispatch`)
or if it was run on schedule. To run it on a commit of a pull request (`pull_request`), include
the `[test-upstream]` tag in the summary line of the commit message.

For changes that are not covered by the CI please use the `[skip-ci]` tag to avoid running the
normal CI.
-->