### PR TITLE
migrate to a trusted publisher workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,32 +2,57 @@ name: Upload package to PyPI
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
-  publish:
-    name: Publish to PyPI
+  build:
+    name: Build packages
     runs-on: ubuntu-latest
+    if: github.repository == 'keewis/blackdoc'
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
           python-version: "3.x"
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip build twine
+          python -m pip install --upgrade pip
+          python -m pip install build twine
       - name: Build
         run: |
-          python -m build --sdist --wheel .
+          python -m build --outdir dist/ .
       - name: Check the built archives
         run: |
           twine check dist/*
           pip install dist/*.whl
           python -m blackdoc --version
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: packages
+          path: dist/*
+
+  publish:
+    name: Upload to PyPI
+    runs-on: ubuntu-latest
+    needs: build
+
+    environment:
+      name: pypi
+      url: https://pypi.org/p/blackdoc
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: packages
+          path: dist/
+
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@37f50c210e3d2f9450da2cd423303d6a14a6e29f
         with:
-          password: ${{ secrets.pypi_token }}
-          repository_url: https://upload.pypi.org/legacy/
           verify_metadata: true


### PR DESCRIPTION
- [x] Passes `pre-commit run --all-files`