### PR TITLE
prepare a new release

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,13 +26,11 @@ Dependencies:
 - `rich`_
 - `tomli`_
 - `pathspec`_
-- `importlib-metadata`_ for ``python < 3.8``
 
 .. _more-itertools: https://github.com/more-itertools/more-itertools
 .. _rich: https://github.com/textualize/rich
 .. _tomli: https://github.com/hukkin/tomli
 .. _pathspec: https://github.com/cpburnz/python-pathspec
-.. _importlib-metadata: https://github.com/python/importlib_metadata
 
 Install it with:
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
-v0.3.9 (*unreleased*)
----------------------
+v0.3.9 (04 November 2023)
+-------------------------
 - support synchronizing the version of the ``black`` hook in more cases (:pull:`180`)
 - document the ``pre-commit`` hooks (:issue:`176`, :pull:`181`)
 - officially support running on python 3.12 (:pull:`185`)

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -4,7 +4,7 @@ v0.3.9 (*unreleased*)
 ---------------------
 - support synchronizing the version of the ``black`` hook in more cases (:pull:`180`)
 - document the ``pre-commit`` hooks (:issue:`176`, :pull:`181`)
-- officially support python 3.12 (:pull:`185`)
+- officially support running on python 3.12 (:pull:`185`)
 - drop support for running on python 3.7 (:pull:`186`)
 
 v0.3.8 (03 November 2022)

--- a/doc/installing.rst
+++ b/doc/installing.rst
@@ -7,7 +7,6 @@ Its dependencies are:
 - `rich`_
 - `tomli`_
 - `pathspec`_
-- `importlib-metadata`_ (on **python** < 3.8)
 
 
 To install it, use
@@ -28,4 +27,3 @@ or with ``conda``:
 .. _rich: https://rich.readthedocs.io/en/latest/
 .. _tomli: https://github.com/hukkin/tomli
 .. _pathspec: https://python-path-specification.readthedocs.io/en/latest/
-.. _importlib-metadata: https://importlib-metadata.readthedocs.io/en/latest/


### PR DESCRIPTION
- [x] Passes `pre-commit run --all-files`

<!--
By default, the upstream-dev CI is only run when triggered by the github website (`workflow_dispatch`)
or if it was run on schedule. To run it on a commit of a pull request (`pull_request`), include
the `[test-upstream]` tag in the summary line of the commit message.

For changes that are not covered by the CI please use the `[skip-ci]` tag to avoid running the
normal CI.
-->