### PR TITLE
experimental `markdown` support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,7 @@ repos:
     rev: v3.5.3
     hooks:
       - id: prettier
+        args: ["--prettier_cache=.prettier_cache/cache"]
   - repo: https://github.com/ComPWA/taplo-pre-commit
     rev: v0.9.3
     hooks:

--- a/blackdoc/__main__.py
+++ b/blackdoc/__main__.py
@@ -99,6 +99,8 @@ def process(args):
         formats.disable(
             set(formats.detection_funcs.keys()) - set(selected_formats) - {"none"}
         )
+    else:
+        formats.disable({"markdown"})
 
     disabled_formats = getattr(args, "disable_formats", None)
     if disabled_formats:

--- a/blackdoc/formats/__init__.py
+++ b/blackdoc/formats/__init__.py
@@ -2,7 +2,7 @@ import textwrap
 
 import more_itertools
 
-from blackdoc.formats import doctest, ipython, none, rst
+from blackdoc.formats import doctest, ipython, markdown, none, rst
 from blackdoc.formats.errors import InvalidFormatError  # noqa: F401
 from blackdoc.formats.register import (
     detection_funcs,  # noqa: F401
@@ -39,5 +39,5 @@ def reformat_code(line_unit, code_format, indentation_depth, **parameters):
     return textwrap.indent(reformatted, " " * indentation_depth)
 
 
-for module in (none, doctest, ipython, rst):
+for module in (none, doctest, ipython, rst, markdown):
     register_format(module.name, module)

--- a/blackdoc/formats/markdown.py
+++ b/blackdoc/formats/markdown.py
@@ -1,0 +1,109 @@
+import itertools
+import re
+import textwrap
+
+import more_itertools
+
+from blackdoc.formats.errors import InvalidFormatError
+
+name = "markdown"
+
+# format:
+# blocks followed by optional whitespace and the word python
+# block fences are three backticks or colons (myst)
+# the word can be wrapped by curly braces
+
+directive_re = re.compile(
+    r"(?P<indent>[ ]*)(?P<fences>[`:]{3})\s*\{?\s*(?P<language>python)\s*\}?"
+)
+include_pattern = r"\.md$"
+
+
+def take_while(iterable, predicate):
+    while True:
+        try:
+            taken = next(iterable)
+        except StopIteration:
+            break
+
+        if not predicate(taken):
+            iterable.prepend(taken)
+            break
+
+        yield taken
+
+
+def continuation_lines(lines, indent, fences):
+    yield from take_while(lines, lambda x: x[1].strip() != fences)
+
+
+def detection_func(lines):
+    try:
+        line_number, line = lines.peek()
+    except StopIteration:
+        return None
+
+    match = directive_re.match(line)
+    if not match:
+        return None
+
+    directive = match.groupdict()
+    indent = len(directive.pop("indent"))
+
+    start_line = more_itertools.first(lines)
+    try:
+        content_lines = list(continuation_lines(lines, indent, directive["fences"]))
+    except RuntimeError as e:
+        if str(e) != "prompt detected":
+            raise
+
+        lines.prepend((line_number, line))
+        return None
+
+    try:
+        line_number, stop_line = lines.peek()
+    except StopIteration:
+        line_number = -1
+        stop_line = None
+
+    if stop_line.strip() != directive.get("fences"):
+        raise RuntimeError("found a code block without closing fence")
+
+    detected_lines = list(
+        itertools.chain([start_line], content_lines, [more_itertools.first(lines)])
+    )
+
+    line_numbers, lines = map(tuple, more_itertools.unzip(detected_lines))
+    line_range = min(line_numbers), max(line_numbers) + 2
+    if line_numbers != tuple(range(line_range[0], line_range[1] - 1)):
+        raise RuntimeError("line numbers are not contiguous")
+
+    return line_range, name, "\n".join(lines)
+
+
+def extraction_func(code):
+    lines = more_itertools.peekable(iter(code.split("\n")))
+
+    match = directive_re.fullmatch(more_itertools.first(lines))
+    if not match:
+        raise InvalidFormatError(f"misformatted code block:\n{code}")
+
+    directive = match.groupdict()
+    directive.pop("indent")
+
+    lines_ = tuple(lines)
+    if len(lines_) == 0:
+        raise InvalidFormatError("misformatted code block: could not find any code")
+
+    indent = len(lines_[0]) - len(lines_[0].lstrip())
+    directive["prompt_length"] = indent
+
+    code_ = textwrap.dedent("\n".join(lines_[:-1]))
+
+    return directive, code_
+
+
+def reformatting_func(code, language, fences):
+    directive = f"{fences}{language}"
+
+    return "\n".join(line for line in (directive, code, fences) if line is not None)

--- a/blackdoc/tests/test_markdown.py
+++ b/blackdoc/tests/test_markdown.py
@@ -105,3 +105,122 @@ def test_detection_func(string, expected):
     actual = markdown.detection_func(code_fragment)
 
     assert actual == construct_expected(expected, string.rstrip())
+
+
+@pytest.mark.parametrize(
+    ["code", "expected"],
+    (
+        pytest.param(
+            textwrap.dedent(
+                """\
+                ```python
+                10 * 5
+                ```
+                """.rstrip()
+            ),
+            (
+                {
+                    "language": "python",
+                    "fences": "```",
+                    "prompt_length": 0,
+                },
+                "10 * 5",
+            ),
+            id="backticks",
+        ),
+        pytest.param(
+            textwrap.dedent(
+                """\
+                ``` python
+                10 * 5
+                ```
+                """.rstrip()
+            ),
+            (
+                {
+                    "language": "python",
+                    "prompt_length": 0,
+                    "fences": "```",
+                },
+                "10 * 5",
+            ),
+            id="backticks-with_space",
+        ),
+        pytest.param(
+            textwrap.dedent(
+                """\
+                ```{python}
+                10 * 5
+                ```
+                """.rstrip()
+            ),
+            (
+                {
+                    "language": "python",
+                    "prompt_length": 0,
+                    "fences": "```",
+                },
+                "10 * 5",
+            ),
+            id="backticks-with_braces",
+        ),
+        pytest.param(
+            textwrap.dedent(
+                """\
+                :::python
+                10 * 5
+                :::
+                """.rstrip()
+            ),
+            (
+                {
+                    "language": "python",
+                    "prompt_length": 0,
+                    "fences": ":::",
+                },
+                "10 * 5",
+            ),
+            id="colons",
+        ),
+        pytest.param(
+            textwrap.dedent(
+                """\
+                ::: python
+                10 * 5
+                :::
+                """.rstrip()
+            ),
+            (
+                {
+                    "language": "python",
+                    "prompt_length": 0,
+                    "fences": ":::",
+                },
+                "10 * 5",
+            ),
+            id="colons-with_space",
+        ),
+        pytest.param(
+            textwrap.dedent(
+                """\
+                :::{python}
+                10 * 5
+                :::
+                """.rstrip()
+            ),
+            (
+                {
+                    "language": "python",
+                    "prompt_length": 0,
+                    "fences": ":::",
+                },
+                "10 * 5",
+            ),
+            id="colons-with_braces",
+        ),
+    ),
+)
+def test_extraction_func(code, expected):
+    actual = markdown.extraction_func(code)
+
+    assert expected == actual

--- a/blackdoc/tests/test_markdown.py
+++ b/blackdoc/tests/test_markdown.py
@@ -1,0 +1,107 @@
+import textwrap
+
+import more_itertools
+import pytest
+
+from blackdoc.formats import markdown
+
+
+@pytest.mark.parametrize(
+    ["string", "expected"],
+    (
+        pytest.param("", None, id="empty string"),
+        pytest.param("Some string.", None, id="no_code"),
+        pytest.param(
+            textwrap.dedent(
+                """\
+                ```
+                This is not a code block.
+                ```
+                """
+            ),
+            None,
+            id="block",
+        ),
+        pytest.param(
+            textwrap.dedent(
+                """\
+                ```sh
+                find . -name "*.py"
+                ```
+                """
+            ),
+            None,
+            id="code_other_language",
+        ),
+        pytest.param(
+            textwrap.dedent(
+                """\
+                ```python
+                10 * 5
+                ```
+                """
+            ),
+            "markdown",
+            id="code",
+        ),
+        pytest.param(
+            textwrap.dedent(
+                """\
+                ``` python
+                10 * 5
+                ```
+                """
+            ),
+            "markdown",
+            id="code-space",
+        ),
+        pytest.param(
+            textwrap.dedent(
+                """\
+                ```{python}
+                10 * 5
+                ```
+                """
+            ),
+            "markdown",
+            id="code-braces",
+        ),
+        pytest.param(
+            textwrap.dedent(
+                """\
+                :::python
+                10 * 5
+                :::
+                """
+            ),
+            "markdown",
+            id="myst-code",
+        ),
+        pytest.param(
+            textwrap.dedent(
+                """\
+                :::{python}
+                10 * 5
+                :::
+                """
+            ),
+            "markdown",
+            id="myst-code-braces",
+        ),
+    ),
+)
+def test_detection_func(string, expected):
+    def construct_expected(label, string):
+        if label is None:
+            return None
+
+        n_lines = len(string.split("\n"))
+
+        range_ = (1, n_lines + 2)
+        return range_, label, string
+
+    lines = string.split("\n")
+    code_fragment = more_itertools.peekable(enumerate(lines, start=1))
+    actual = markdown.detection_func(code_fragment)
+
+    assert actual == construct_expected(expected, string.rstrip())

--- a/blackdoc/tests/test_markdown.py
+++ b/blackdoc/tests/test_markdown.py
@@ -224,3 +224,44 @@ def test_extraction_func(code, expected):
     actual = markdown.extraction_func(code)
 
     assert expected == actual
+
+
+@pytest.mark.parametrize(
+    ("code", "directive", "expected"),
+    (
+        pytest.param(
+            "10 * 5",
+            {
+                "language": "python",
+                "fences": "```",
+            },
+            textwrap.dedent(
+                """\
+                ```python
+                10 * 5
+                ```
+                """.rstrip()
+            ),
+            id="backticks",
+        ),
+        pytest.param(
+            "10 * 5",
+            {
+                "language": "python",
+                "fences": ":::",
+            },
+            textwrap.dedent(
+                """\
+                :::python
+                10 * 5
+                :::
+                """.rstrip()
+            ),
+            id="colons",
+        ),
+    ),
+)
+def test_reformatting_func(code, directive, expected):
+    actual = markdown.reformatting_func(code, **directive)
+
+    assert expected == actual

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -2,6 +2,7 @@ Changelog
 =========
 v0.3.10 (*unreleased*)
 ----------------------
+- formatting support for markdown (:pull:`225`)
 - officially support running on python 3.13 (:pull:`216`)
 - drop support for running on python 3.8 and 3.9 (:pull:`215`, :pull:`226`)
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -9,6 +9,7 @@ The currently supported formats are:
 - doctest
 - ipython
 - rst
+- markdown (python blocks only for now, no pycon)
 
 Documentation
 -------------

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -9,7 +9,7 @@ The currently supported formats are:
 - doctest
 - ipython
 - rst
-- markdown (python blocks only for now, no pycon)
+- markdown (``python`` blocks only for now, no ``pycon`` blocks)
 
 Documentation
 -------------


### PR DESCRIPTION
I've contributed to enough documentation pages that use `myst` to wish for `blackdoc` to support markdown, so here it is.

- [x] Tests added
- [x] Passes `pre-commit run --all-files`
- [x] User visible changes (including notable bug fixes) are documented in `changelog.rst`
- [x] New features are documented in the docs