### PR TITLE
extended support for markdown

### DIFF
--- a/blackdoc/formats/markdown.py
+++ b/blackdoc/formats/markdown.py
@@ -156,7 +156,26 @@ def extraction_func(code):
     return directive, code_
 
 
-def reformatting_func(code, language, fences):
-    directive = f"{fences}{language}"
+def reformatting_func(code, block_type, fences, braces, options):
+    if braces:
+        brace_open = "{"
+        brace_close = "}"
+    else:
+        brace_open = ""
+        brace_close = ""
 
-    return "\n".join(line for line in (directive, code, fences) if line is not None)
+    directive = f"{fences}{brace_open}{block_type}{brace_close}"
+    parts = [directive]
+    if options:
+        parts.append(
+            "\n".join(
+                [
+                    "---",
+                    *options,
+                    "---",
+                ]
+            )
+        )
+    parts.extend([code, fences])
+
+    return "\n".join(part for part in parts if part is not None)

--- a/blackdoc/formats/markdown.py
+++ b/blackdoc/formats/markdown.py
@@ -14,7 +14,7 @@ name = "markdown"
 # the word can be wrapped by curly braces
 
 directive_re = re.compile(
-    r"(?P<indent>[ ]*)(?P<fences>[`:]{3})\s*\{?\s*(?P<language>python)\s*\}?"
+    r"(?P<indent>[ ]*)(?P<fences>[`:]{3})\s*\{?\s*(?P<block_type>[-a-z]+)\s*\}?"
 )
 include_pattern = r"\.md$"
 
@@ -48,6 +48,9 @@ def detection_func(lines):
         return None
 
     directive = match.groupdict()
+    if directive["block_type"] not in ("python", "jupyter-execute"):
+        return None
+
     indent = len(directive.pop("indent"))
 
     start_line = more_itertools.first(lines)

--- a/blackdoc/formats/markdown.py
+++ b/blackdoc/formats/markdown.py
@@ -5,6 +5,7 @@ import textwrap
 import more_itertools
 
 from blackdoc.formats.errors import InvalidFormatError
+from blackdoc.formats.ipython import hide_magic, reveal_magic
 from blackdoc.formats.rst import has_prompt
 
 name = "markdown"
@@ -162,7 +163,7 @@ def extraction_func(code):
 
     code_ = textwrap.dedent("\n".join(lines_[:-1]))
 
-    return directive, code_
+    return directive, hide_magic(code_)
 
 
 def reformatting_func(code, block_type, fences, braces, options):
@@ -185,6 +186,6 @@ def reformatting_func(code, block_type, fences, braces, options):
                 ]
             )
         )
-    parts.extend([code, fences])
+    parts.extend([reveal_magic(code), fences])
 
     return "\n".join(part for part in parts if part is not None)

--- a/blackdoc/formats/markdown.py
+++ b/blackdoc/formats/markdown.py
@@ -5,6 +5,7 @@ import textwrap
 import more_itertools
 
 from blackdoc.formats.errors import InvalidFormatError
+from blackdoc.formats.rst import has_prompt
 
 name = "markdown"
 
@@ -83,6 +84,12 @@ def extract_options(lines, fences):
 
 def continuation_lines(lines, indent, fences):
     options = extract_options(lines, fences)
+    newlines = tuple(take_while(lines, lambda x: not x[1].strip()))
+
+    _, next_line = lines.peek((0, None))
+    if has_prompt(next_line):
+        lines.prepend(*options, *newlines)
+        raise RuntimeError("prompt detected")
 
     yield from options
     yield from take_while(lines, lambda x: x[1].strip() != fences)

--- a/blackdoc/formats/markdown.py
+++ b/blackdoc/formats/markdown.py
@@ -59,11 +59,11 @@ def extract_options(lines, fences):
     if line.strip() != "---":
         return ()
 
-    options = [next(line)]
+    options = [next(lines)]
     # potentially found options
     while True:
         try:
-            taken = next(line)
+            taken = next(lines)
         except StopIteration:
             break
 
@@ -142,7 +142,7 @@ def extraction_func(code):
 
     directive = preprocess_directive(match.groupdict())
     directive.pop("indent")
-    directive["options"] = extract_options(lines, directive["fences"])
+    directive["options"] = extract_options(lines, directive["fences"])[1:-1]
 
     lines_ = tuple(lines)
     if len(lines_) == 0:

--- a/blackdoc/formats/markdown.py
+++ b/blackdoc/formats/markdown.py
@@ -15,6 +15,7 @@ name = "markdown"
 
 directive_re = re.compile(
     r"""(?x)
+    ^
     (?P<indent>[ ]*)
     (?P<fences>[`:]{3})
     \s*
@@ -22,6 +23,7 @@ directive_re = re.compile(
       (?P<braces>\{\s*(?P<block_type1>[-a-z0-9]+)\s*\})
       |(?P<block_type2>[-a-z0-9]+)
     )
+    $
     """
 )
 include_pattern = r"\.md$"

--- a/blackdoc/formats/markdown.py
+++ b/blackdoc/formats/markdown.py
@@ -19,8 +19,8 @@ directive_re = re.compile(
     (?P<fences>[`:]{3})
     \s*
     (?:
-      (?P<braces>\{\s*(?P<block_type1>[-a-z]+)\s*\})
-      |(?P<block_type2>[-a-z]+)
+      (?P<braces>\{\s*(?P<block_type1>[-a-z0-9]+)\s*\})
+      |(?P<block_type2>[-a-z0-9]+)
     )
     """
 )
@@ -97,7 +97,7 @@ def detection_func(lines):
         return None
 
     directive = preprocess_directive(match.groupdict())
-    if directive["block_type"] not in ("python", "jupyter-execute"):
+    if directive["block_type"] not in ("python", "python3", "jupyter-execute"):
         return None
 
     indent = len(directive.pop("indent"))

--- a/blackdoc/tests/test_markdown.py
+++ b/blackdoc/tests/test_markdown.py
@@ -69,6 +69,28 @@ from blackdoc.formats import markdown
         pytest.param(
             textwrap.dedent(
                 """\
+                ```jupyter-execute
+                10 * 5
+                ```
+                """
+            ),
+            "markdown",
+            id="jupyter-execute",
+        ),
+        pytest.param(
+            textwrap.dedent(
+                """\
+                ```{jupyter-execute}
+                10 * 5
+                ```
+                """
+            ),
+            "markdown",
+            id="jupyter-execute-braces",
+        ),
+        pytest.param(
+            textwrap.dedent(
+                """\
                 :::python
                 10 * 5
                 :::
@@ -87,6 +109,28 @@ from blackdoc.formats import markdown
             ),
             "markdown",
             id="myst-code-braces",
+        ),
+        pytest.param(
+            textwrap.dedent(
+                """\
+                :::{python}
+                10 * 5
+                :::
+                """
+            ),
+            "markdown",
+            id="myst-jupyter-execute",
+        ),
+        pytest.param(
+            textwrap.dedent(
+                """\
+                :::{python}
+                10 * 5
+                :::
+                """
+            ),
+            "markdown",
+            id="myst-jupyter-execute-braces",
         ),
     ),
 )
@@ -120,9 +164,9 @@ def test_detection_func(string, expected):
             ),
             (
                 {
-                    "language": "python",
-                    "fences": "```",
+                    "block_type": "python",
                     "prompt_length": 0,
+                    "fences": "```",
                 },
                 "10 * 5",
             ),
@@ -138,7 +182,7 @@ def test_detection_func(string, expected):
             ),
             (
                 {
-                    "language": "python",
+                    "block_type": "python",
                     "prompt_length": 0,
                     "fences": "```",
                 },
@@ -156,13 +200,31 @@ def test_detection_func(string, expected):
             ),
             (
                 {
-                    "language": "python",
+                    "block_type": "python",
                     "prompt_length": 0,
                     "fences": "```",
                 },
                 "10 * 5",
             ),
             id="backticks-with_braces",
+        ),
+        pytest.param(
+            textwrap.dedent(
+                """\
+                ```{jupyter-execute}
+                10 * 5
+                ```
+                """.rstrip()
+            ),
+            (
+                {
+                    "block_type": "jupyter-execute",
+                    "prompt_length": 0,
+                    "fences": "```",
+                },
+                "10 * 5",
+            ),
+            id="backticks-jupyter-execute-with_braces",
         ),
         pytest.param(
             textwrap.dedent(
@@ -174,7 +236,7 @@ def test_detection_func(string, expected):
             ),
             (
                 {
-                    "language": "python",
+                    "block_type": "python",
                     "prompt_length": 0,
                     "fences": ":::",
                 },
@@ -192,7 +254,7 @@ def test_detection_func(string, expected):
             ),
             (
                 {
-                    "language": "python",
+                    "block_type": "python",
                     "prompt_length": 0,
                     "fences": ":::",
                 },
@@ -210,13 +272,31 @@ def test_detection_func(string, expected):
             ),
             (
                 {
-                    "language": "python",
+                    "block_type": "python",
                     "prompt_length": 0,
                     "fences": ":::",
                 },
                 "10 * 5",
             ),
             id="colons-with_braces",
+        ),
+        pytest.param(
+            textwrap.dedent(
+                """\
+                :::{jupyter-execute}
+                10 * 5
+                :::
+                """.rstrip()
+            ),
+            (
+                {
+                    "block_type": "jupyter-execute",
+                    "prompt_length": 0,
+                    "fences": ":::",
+                },
+                "10 * 5",
+            ),
+            id="colons-jupyter-execute",
         ),
     ),
 )
@@ -232,7 +312,7 @@ def test_extraction_func(code, expected):
         pytest.param(
             "10 * 5",
             {
-                "language": "python",
+                "block_type": "python",
                 "fences": "```",
             },
             textwrap.dedent(
@@ -247,7 +327,22 @@ def test_extraction_func(code, expected):
         pytest.param(
             "10 * 5",
             {
-                "language": "python",
+                "block_type": "jupyter-execute",
+                "fences": "```",
+            },
+            textwrap.dedent(
+                """\
+                ```{jupyter-execute}
+                10 * 5
+                ```
+                """.rstrip()
+            ),
+            id="jupyter-execute-with_braces",
+        ),
+        pytest.param(
+            "10 * 5",
+            {
+                "block_type": "python",
                 "fences": ":::",
             },
             textwrap.dedent(

--- a/blackdoc/tests/test_markdown.py
+++ b/blackdoc/tests/test_markdown.py
@@ -237,6 +237,29 @@ def test_detection_func(string, expected):
         pytest.param(
             textwrap.dedent(
                 """\
+                ```{jupyter-execute}
+                ---
+                hide-code: true
+                ---
+                10 * 5
+                ```
+                """.rstrip()
+            ),
+            (
+                {
+                    "block_type": "jupyter-execute",
+                    "prompt_length": 0,
+                    "fences": "```",
+                    "braces": True,
+                    "options": ("hide-code: true",),
+                },
+                "10 * 5",
+            ),
+            id="backticks-jupyter-execute-with_options",
+        ),
+        pytest.param(
+            textwrap.dedent(
+                """\
                 :::python
                 10 * 5
                 :::

--- a/blackdoc/tests/test_markdown.py
+++ b/blackdoc/tests/test_markdown.py
@@ -168,6 +168,7 @@ def test_detection_func(string, expected):
                     "prompt_length": 0,
                     "fences": "```",
                     "braces": False,
+                    "options": (),
                 },
                 "10 * 5",
             ),
@@ -187,6 +188,7 @@ def test_detection_func(string, expected):
                     "prompt_length": 0,
                     "fences": "```",
                     "braces": False,
+                    "options": (),
                 },
                 "10 * 5",
             ),
@@ -206,6 +208,7 @@ def test_detection_func(string, expected):
                     "prompt_length": 0,
                     "fences": "```",
                     "braces": True,
+                    "options": (),
                 },
                 "10 * 5",
             ),
@@ -225,6 +228,7 @@ def test_detection_func(string, expected):
                     "prompt_length": 0,
                     "fences": "```",
                     "braces": True,
+                    "options": (),
                 },
                 "10 * 5",
             ),
@@ -244,6 +248,7 @@ def test_detection_func(string, expected):
                     "prompt_length": 0,
                     "fences": ":::",
                     "braces": False,
+                    "options": (),
                 },
                 "10 * 5",
             ),
@@ -263,6 +268,7 @@ def test_detection_func(string, expected):
                     "prompt_length": 0,
                     "fences": ":::",
                     "braces": False,
+                    "options": (),
                 },
                 "10 * 5",
             ),
@@ -282,6 +288,7 @@ def test_detection_func(string, expected):
                     "prompt_length": 0,
                     "fences": ":::",
                     "braces": True,
+                    "options": (),
                 },
                 "10 * 5",
             ),
@@ -301,6 +308,7 @@ def test_detection_func(string, expected):
                     "prompt_length": 0,
                     "fences": ":::",
                     "braces": True,
+                    "options": (),
                 },
                 "10 * 5",
             ),
@@ -323,6 +331,7 @@ def test_extraction_func(code, expected):
                 "block_type": "python",
                 "fences": "```",
                 "options": (),
+                "braces": False,
             },
             textwrap.dedent(
                 """\
@@ -339,15 +348,20 @@ def test_extraction_func(code, expected):
                 "block_type": "jupyter-execute",
                 "fences": "```",
                 "braces": True,
+                "options": ("hide-code: true", "hide-output: true"),
             },
             textwrap.dedent(
                 """\
                 ```{jupyter-execute}
+                ---
+                hide-code: true
+                hide-output: true
+                ---
                 10 * 5
                 ```
                 """.rstrip()
             ),
-            id="jupyter-execute-with_braces",
+            id="jupyter-execute-with_options-with_braces",
         ),
         pytest.param(
             "10 * 5",
@@ -355,6 +369,7 @@ def test_extraction_func(code, expected):
                 "block_type": "python",
                 "fences": ":::",
                 "braces": False,
+                "options": (),
             },
             textwrap.dedent(
                 """\

--- a/blackdoc/tests/test_markdown.py
+++ b/blackdoc/tests/test_markdown.py
@@ -376,6 +376,32 @@ def test_detection_func(string, expected):
             ),
             id="colons-jupyter-execute",
         ),
+        pytest.param(
+            textwrap.dedent(
+                """\
+                :::python
+                %load_ext extension
+                10 * 5
+                :::
+                """.rstrip()
+            ),
+            (
+                {
+                    "block_type": "python",
+                    "fences": ":::",
+                    "braces": False,
+                    "options": (),
+                    "prompt_length": 0,
+                },
+                textwrap.dedent(
+                    """\
+                    # <ipython-magic>%load_ext extension
+                    10 * 5
+                    """.rstrip()
+                ),
+            ),
+            id="ipython_magic",
+        ),
     ),
 )
 def test_extraction_func(code, expected):
@@ -441,6 +467,29 @@ def test_extraction_func(code, expected):
                 """.rstrip()
             ),
             id="colons",
+        ),
+        pytest.param(
+            textwrap.dedent(
+                """\
+                # <ipython-magic>%load_ext extension
+                10 * 5
+                """.rstrip()
+            ),
+            {
+                "block_type": "python",
+                "fences": ":::",
+                "braces": False,
+                "options": (),
+            },
+            textwrap.dedent(
+                """\
+                :::python
+                %load_ext extension
+                10 * 5
+                :::
+                """.rstrip()
+            ),
+            id="ipython_magic",
         ),
     ),
 )

--- a/blackdoc/tests/test_markdown.py
+++ b/blackdoc/tests/test_markdown.py
@@ -167,6 +167,7 @@ def test_detection_func(string, expected):
                     "block_type": "python",
                     "prompt_length": 0,
                     "fences": "```",
+                    "braces": False,
                 },
                 "10 * 5",
             ),
@@ -185,6 +186,7 @@ def test_detection_func(string, expected):
                     "block_type": "python",
                     "prompt_length": 0,
                     "fences": "```",
+                    "braces": False,
                 },
                 "10 * 5",
             ),
@@ -203,6 +205,7 @@ def test_detection_func(string, expected):
                     "block_type": "python",
                     "prompt_length": 0,
                     "fences": "```",
+                    "braces": True,
                 },
                 "10 * 5",
             ),
@@ -221,6 +224,7 @@ def test_detection_func(string, expected):
                     "block_type": "jupyter-execute",
                     "prompt_length": 0,
                     "fences": "```",
+                    "braces": True,
                 },
                 "10 * 5",
             ),
@@ -239,6 +243,7 @@ def test_detection_func(string, expected):
                     "block_type": "python",
                     "prompt_length": 0,
                     "fences": ":::",
+                    "braces": False,
                 },
                 "10 * 5",
             ),
@@ -257,6 +262,7 @@ def test_detection_func(string, expected):
                     "block_type": "python",
                     "prompt_length": 0,
                     "fences": ":::",
+                    "braces": False,
                 },
                 "10 * 5",
             ),
@@ -275,6 +281,7 @@ def test_detection_func(string, expected):
                     "block_type": "python",
                     "prompt_length": 0,
                     "fences": ":::",
+                    "braces": True,
                 },
                 "10 * 5",
             ),
@@ -293,6 +300,7 @@ def test_detection_func(string, expected):
                     "block_type": "jupyter-execute",
                     "prompt_length": 0,
                     "fences": ":::",
+                    "braces": True,
                 },
                 "10 * 5",
             ),
@@ -314,6 +322,7 @@ def test_extraction_func(code, expected):
             {
                 "block_type": "python",
                 "fences": "```",
+                "options": (),
             },
             textwrap.dedent(
                 """\
@@ -329,6 +338,7 @@ def test_extraction_func(code, expected):
             {
                 "block_type": "jupyter-execute",
                 "fences": "```",
+                "braces": True,
             },
             textwrap.dedent(
                 """\
@@ -344,6 +354,7 @@ def test_extraction_func(code, expected):
             {
                 "block_type": "python",
                 "fences": ":::",
+                "braces": False,
             },
             textwrap.dedent(
                 """\

--- a/blackdoc/tests/test_markdown.py
+++ b/blackdoc/tests/test_markdown.py
@@ -37,6 +37,30 @@ from blackdoc.formats import markdown
             textwrap.dedent(
                 """\
                 ```python
+                >>> 10 * 5
+                ```
+                """
+            ),
+            None,
+            id="doctest_prompt",
+        ),
+        pytest.param(
+            textwrap.dedent(
+                """\
+                ```python
+                In [1]: 10 * 5
+                Out[1]:
+                50
+                ```
+                """
+            ),
+            None,
+            id="ipython_prompt",
+        ),
+        pytest.param(
+            textwrap.dedent(
+                """\
+                ```python
                 10 * 5
                 ```
                 """

--- a/blackdoc/tests/test_markdown.py
+++ b/blackdoc/tests/test_markdown.py
@@ -91,6 +91,20 @@ from blackdoc.formats import markdown
         pytest.param(
             textwrap.dedent(
                 """\
+                ```{jupyter-execute}
+                ---
+                hide-code: true
+                ---
+                10 * 5
+                ```
+                """
+            ),
+            "markdown",
+            id="jupyter-execute-braces-with_options",
+        ),
+        pytest.param(
+            textwrap.dedent(
+                """\
                 :::python
                 10 * 5
                 :::
@@ -240,6 +254,7 @@ def test_detection_func(string, expected):
                 ```{jupyter-execute}
                 ---
                 hide-code: true
+                hide-output: true
                 ---
                 10 * 5
                 ```
@@ -251,7 +266,7 @@ def test_detection_func(string, expected):
                     "prompt_length": 0,
                     "fences": "```",
                     "braces": True,
-                    "options": ("hide-code: true",),
+                    "options": ("hide-code: true", "hide-output: true"),
                 },
                 "10 * 5",
             ),

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -2,7 +2,7 @@ Changelog
 =========
 v0.3.11 (*unreleased*)
 ----------------------
-
+- extended support for markdown (:pull:`225`)
 
 v0.3.10 (09 June 2025)
 ----------------------

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -9,7 +9,7 @@ The currently supported formats are:
 - doctest
 - ipython
 - rst
-- markdown (``python`` blocks only for now, no ``pycon`` blocks)
+- markdown
 
 Documentation
 -------------


### PR DESCRIPTION
With this PR we support markdown block options, preserve braces around the block type, and also support `jupyter-execute` blocks.

~~Still missing: ipython magic in python cells.~~

- [x] follow-up to #225
- [x] Tests added
- [x] Passes `pre-commit run --all-files`
- [x] User visible changes (including notable bug fixes) are documented in `changelog.rst`
- [x] New features are documented in the docs