### PR TITLE
auto-format markdown files with `pre-commit`

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -5,7 +5,7 @@
   language_version: python3
   require_serial: true
   types: [file]
-  types_or: [python, rst]
+  types_or: [python, rst, markdown]
 
 - id: blackdoc-autoupdate-black
   name: autoupdate-black


### PR DESCRIPTION
Now that we support markdown, this should run in `pre-commit`, as well.