### PR TITLE
release 0.4.0

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -3,6 +3,7 @@ Changelog
 v0.3.11 (*unreleased*)
 ----------------------
 - extended support for markdown (:pull:`225`)
+- enable markdown in `pre-commit` (:pull:`233`)
 
 v0.3.10 (09 June 2025)
 ----------------------

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
-v0.3.11 (*unreleased*)
-----------------------
+v0.4.0 (14 June 2025)
+---------------------
 - extended support for markdown (:pull:`225`)
 - enable markdown in `pre-commit` (:pull:`233`)
 


### PR DESCRIPTION
The markdown support should have already increased the major version for the last release, but enabling markdown in `pre-commit` will have a even bigger impact.