### PR TITLE
remove the call to `jupyter_dependencies_are_installed`

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ build:
       - (git --no-pager log --pretty="tformat:%s" -1 | grep -vqF "[skip-rtd]") || exit 183
       - git fetch --unshallow || true
     pre_install:
-      - git update-index --assume-unchanged docs/conf.py ci/requirements/doc.txt
+      - git update-index --assume-unchanged doc/conf.py ci/requirements/doc.txt
 
 python:
   install:

--- a/blackdoc/blackcompat.py
+++ b/blackdoc/blackcompat.py
@@ -251,10 +251,10 @@ def gen_python_files(
             )
 
         elif child.is_file():
-            if child.suffix == ".ipynb" and not jupyter_dependencies_are_installed(
-                verbose=verbose, quiet=quiet
-            ):
-                continue
+            # if child.suffix == ".ipynb" and not jupyter_dependencies_are_installed(
+            #     verbose=verbose, quiet=quiet
+            # ):
+            #     continue
             include_match = include.search(normalized_path) if include else True
             if include_match:
                 yield child


### PR DESCRIPTION
`blackdoc` doesn't support ipython files.