### PR TITLE
release

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
-v0.4.2 (*unreleased*)
----------------------
+v0.4.2 (28 September 2025)
+--------------------------
 - support ``code-cell`` markdown blocks (:pull:`243`)
 - compatibility with ``black>=25.9.0`` (:pull:`249`)
 

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -3,6 +3,7 @@ Changelog
 v0.4.2 (*unreleased*)
 ---------------------
 - support ``code-cell`` markdown blocks (:pull:`243`)
+- compatibility with ``black>=25.9.0`` (:pull:`249`)
 
 v0.4.1 (26 June 2025)
 ---------------------


### PR DESCRIPTION
This contains:
- support for `code-cell` blocks
- compatibility with `black=25.9.0`