### PR TITLE
Fix TypeError: decode_bytes() missing required argument 'mode' (pos 2)

### DIFF
--- a/blackdoc/__main__.py
+++ b/blackdoc/__main__.py
@@ -58,7 +58,7 @@ def format_and_overwrite(path, mode):
 def format_and_check(path, mode, diff=False, color=False):
     try:
         with open(path, mode="rb") as f:
-            content, _, _ = black.decode_bytes(f.read())
+            content, _, _ = decode_bytes(f.read())
 
         lines = content.split("\n")
 


### PR DESCRIPTION
- [ ] Closes #248

See https://github.com/keewis/blackdoc/issues/248#issuecomment-3349496287

<!--
By default, the upstream-dev CI is only run when triggered by the github website (`workflow_dispatch`)
or if it was run on schedule. To run it on a commit of a pull request (`pull_request`), include
the `[test-upstream]` tag in the summary line of the commit message.

For changes that are not covered by the CI please use the `[skip-ci]` tag to avoid running the
normal CI.
-->
